### PR TITLE
Updated website source code repository.

### DIFF
--- a/xml/en/download.xml
+++ b/xml/en/download.xml
@@ -8,7 +8,7 @@
 <article name="nginx: download"
          link="/en/download.html"
          lang="en"
-         rev="2">
+         rev="3">
 
 
 <section name="Mainline version">
@@ -35,21 +35,22 @@
 <section name="Source Code">
 
 <para>
-Read-only Mercurial repositories:
+Source code:
 <list type="bullet">
 
 <listitem>
-code: <literal>http://hg.nginx.org/nginx</literal>
+Read-only Mercurial repository: <literal>http://hg.nginx.org/nginx</literal>
 </listitem>
 <listitem>
-site: <literal>http://hg.nginx.org/nginx.org</literal>
+<link url="http://trac.nginx.org/nginx/browser">Trac source browser</link>
 </listitem>
+<listitem>
 
 </list>
 </para>
 
 <para>
-<link url="http://trac.nginx.org/nginx/browser">Trac source browser</link>
+<link url="https://github.com/nginx/nginx.org">Website sources</link>
 </para>
 
 </section>

--- a/xml/ru/download.xml
+++ b/xml/ru/download.xml
@@ -8,7 +8,7 @@
 <article name="nginx: скачать"
          link="/ru/download.html"
          lang="ru"
-         rev="2">
+         rev="3">
 
 
 <section name="Основная версия">
@@ -35,25 +35,29 @@
 <section name="Исходный код">
 
 <para>
-Репозитории Mercurial, доступные только для чтения:
+Исходный код:
 <list type="bullet">
 
 <listitem>
-код: <literal>http://hg.nginx.org/nginx</literal>
+Репозитории Mercurial, доступные только для чтения:
+<literal>http://hg.nginx.org/nginx</literal>
 </listitem>
 <listitem>
-сайт: <literal>http://hg.nginx.org/nginx.org</literal>
+<link url="http://trac.nginx.org/nginx/browser">Исходный код в Trac</link>
 </listitem>
 
 </list>
 </para>
 
 <para>
-<link url="http://trac.nginx.org/nginx/browser">Исходный код в Trac</link>
+<link url="https://github.com/nginx/nginx.org">вебсайт код</link>
 </para>
 
 </section>
 
+
+<para>
+</para>
 
 <section name="Готовые пакеты">
 


### PR DESCRIPTION
The website sources are now on GitHub. Removed the Mercurial reference and
adjusted the layout slightly to separate source code from website sources.
