### PR TITLE
Update nav menu blog target to reference new blog subdomain

### DIFF
--- a/xml/menu.xml
+++ b/xml/menu.xml
@@ -34,7 +34,7 @@
 
 <item href="http://trac.nginx.org/nginx"> trac </item>
 <item href="http://twitter.com/nginxorg"> twitter </item>
-<item href="http://nginx.com/blog/"> blog </item>
+<item href="https://blog.nginx.org/"> blog </item>
 <item />
 
 <item href="https://unit.nginx.org/"> unit </item>
@@ -87,7 +87,7 @@
 
 <item href="http://trac.nginx.org/nginx"> trac </item>
 <item href="http://twitter.com/nginxorg"> twitter </item>
-<item href="https://www.nginx.com/blog/"> blog </item>
+<item href="https://blog.nginx.org/"> blog </item>
 <item />
 
 <item href="https://unit.nginx.org/"> unit </item>
@@ -122,7 +122,7 @@
 
 <item href="http://trac.nginx.org/nginx"> trac </item>
 <item href="http://twitter.com/nginxorg"> twitter </item>
-<item href="http://nginx.com/blog/"> blog </item>
+<item href="https://blog.nginx.org/"> blog </item>
 <item />
 
 <item href="https://unit.nginx.org/"> unit </item>
@@ -158,7 +158,7 @@
 
 <item href="http://trac.nginx.org/nginx"> trac </item>
 <item href="http://twitter.com/nginxorg"> twitter </item>
-<item href="http://nginx.com/blog/"> blog </item>
+<item href="http://blog.nginx.org/"> blog </item>
 <item />
 
 <item href="https://unit.nginx.org/"> unit </item>
@@ -194,7 +194,7 @@
 
 <item href="http://trac.nginx.org/nginx"> trac </item>
 <item href="http://twitter.com/nginxorg"> twitter </item>
-<item href="https://www.nginx.com/blog/"> blog </item>
+<item href="https://blog.nginx.org/"> blog </item>
 <item />
 
 <item href="https://unit.nginx.org/"> unit </item>
@@ -231,7 +231,7 @@
 
 <item href="http://trac.nginx.org/nginx"> trac </item>
 <item href="http://twitter.com/nginxorg"> twitter </item>
-<item href="http://nginx.com/blog/"> blog </item>
+<item href="https://blog.nginx.org/"> blog </item>
 <item />
 
 <item href="https://unit.nginx.org/"> unit </item>
@@ -267,7 +267,7 @@
 
 <item href="http://trac.nginx.org/nginx"> trac </item>
 <item href="http://twitter.com/nginxorg"> twitter </item>
-<item href="http://nginx.com/blog/"> blog </item>
+<item href="https://blog.nginx.org/"> blog </item>
 <item />
 
 <item href="https://unit.nginx.org/"> unit </item>


### PR DESCRIPTION
## Proposed Changes

Updated all existing nav menu links to reference the new `blog.nginx.org` subdomain (intended for OSS/Community specific usage) instead of `nginx.com/blog`. 

_These changes should ideally go live on 5/15/24, coinciding with the updated NGINX.com redirect rules planned to go into effect._

* `blog.nginx.org` is already live with the selection of posts targeted for migration
*  On 5/15/24, `NGINX.com` will apply redirect rules for select blog posts targeted for migration towards `blog.nginx.org`

### Additional Notes

Updated for all languages, regardless of their actual usage, as this was just a find & replace operation for `nginx.com/blog` -> `blog.nginx.org`