### PR TITLE
Fixed broken link for Admin's Guide.

### DIFF
--- a/xml/en/docs/index.xml
+++ b/xml/en/docs/index.xml
@@ -8,7 +8,7 @@
 <article name="nginx documentation"
          link="/en/docs/"
          lang="en"
-         rev="51"
+         rev="52"
          toc="no">
 
 
@@ -30,7 +30,7 @@
 </listitem>
 
 <listitem>
-<link url="https://www.nginx.com/resources/admin-guide/">Admin’s Guide</link>
+<link url="https://docs.nginx.com/nginx/admin-guide/">Admin’s Guide</link>
 </listitem>
 
 <listitem>

--- a/xml/ru/docs/index.xml
+++ b/xml/ru/docs/index.xml
@@ -8,7 +8,7 @@
 <article name="nginx: документация"
          link="/ru/docs/"
          lang="ru"
-         rev="51"
+         rev="52"
          toc="no">
 
 
@@ -30,7 +30,7 @@
 </listitem>
 
 <listitem>
-<link url="https://www.nginx.com/resources/admin-guide/">Руководство администратора</link> [en]
+<link url="https://docs.nginx.com/nginx/admin-guide/">Руководство администратора</link> [en]
 </listitem>
 
 <listitem>


### PR DESCRIPTION
This current link to Admin's Guide (https://www.nginx.com/resources/admin-guide/) leads to a 404 not found web page. This new link (https://docs.nginx.com/nginx/admin-guide/) seems to be the intended destination.