### PR TITLE
Updated link to commercial subscription.

### DIFF
--- a/xsls/versions.xsls
+++ b/xsls/versions.xsls
@@ -16,7 +16,7 @@ X:template = "stable_version" {
 }
 
 X:template = "commercial_version" {
-    <a href="https://www.f5.com/products">
+    <a href="https://www.f5.com/products/nginx">
     !!;
     </a>
 }

--- a/xslt/versions.xslt
+++ b/xslt/versions.xslt
@@ -17,7 +17,7 @@
 </xsl:template>
 
 <xsl:template match="commercial_version">
-    <a href="https://www.f5.com/products">
+    <a href="https://www.f5.com/products/nginx">
     <xsl:apply-templates/>
     </a>
 </xsl:template>


### PR DESCRIPTION
Currently, the link points to F5 whole product family range instead of NGINX product range