### PR TITLE
Drop Netcraft survey mention

### DIFF
--- a/xml/en/index.xml
+++ b/xml/en/index.xml
@@ -8,7 +8,7 @@
 <article name="nginx"
          link="/en/"
          lang="en"
-         rev="166">
+         rev="167">
 
 
 <section>
@@ -24,9 +24,6 @@ on many heavily loaded Russian sites including
 <link url="http://mail.ru">Mail.Ru</link>,
 <link url="http://vk.com">VK</link>, and
 <link url="http://www.rambler.ru">Rambler</link>.
-According to Netcraft, nginx served or proxied
-<link url="https://www.netcraft.com/blog/may-2024-web-server-survey/">20.42%
-busiest sites in May 2024</link>.
 Here are some of the success stories:
 <link url="https://blogs.dropbox.com/tech/2017/09/optimizing-web-servers-for-high-throughput-and-low-latency/">Dropbox</link>,
 <link url="https://openconnect.netflix.com/en/software/">Netflix</link>,

--- a/xml/ru/index.xml
+++ b/xml/ru/index.xml
@@ -8,7 +8,7 @@
 <article name="nginx"
          link="/ru/"
          lang="ru"
-         rev="166">
+         rev="167">
 
 
 <section>
@@ -24,9 +24,6 @@ nginx [engine x]&mdash;это HTTP-сервер и обратный прокси
 <link url="http://mail.ru">Mail.Ru</link>,
 <link url="http://vk.com">ВКонтакте</link> и
 <link url="http://www.rambler.ru">Рамблер</link>.
-Согласно статистике Netcraft nginx обслуживал или проксировал
-<link url="https://www.netcraft.com/blog/may-2024-web-server-survey/">20.42%
-самых нагруженных сайтов в мае 2024 года</link>.
 Вот некоторые примеры успешного внедрения nginx (тексты на английском языке):
 <link url="https://blogs.dropbox.com/tech/2017/09/optimizing-web-servers-for-high-throughput-and-low-latency/">Dropbox</link>,
 <link url="https://openconnect.netflix.com/en/software/">Netflix</link>,


### PR DESCRIPTION
While netcraft survey was a useful metric and marketing tool it has lost its value by now.
At the same time, tracking changes into the survey is a monthly chore which has little to no use.
This pull request drops the survey mention.

Optionally, we can leave a link to netcraft surveys (which is https://www.netcraft.com/resources/?type=blog&search=survey&topic=web-server-survey ) but IMO it makes not sense as well.