### PR TITLE
Improve add_header documentation

### DIFF
--- a/xml/en/docs/http/ngx_http_headers_module.xml
+++ b/xml/en/docs/http/ngx_http_headers_module.xml
@@ -72,6 +72,10 @@ If the <literal>always</literal> parameter is specified (1.7.5),
 the header field will be added regardless of the response code.
 </para>
 
+<para>
+The add_header directive will not generate a header if the value provided is an empty string.
+</para>
+
 </directive>
 
 


### PR DESCRIPTION
One liner documentation addition

> The add_header directive will not generate a header if the value provided is an empty string.

closes #50 