### PR TITLE
Linux packages: Actualized the list of supported distributions.

### DIFF
--- a/xml/en/linux_packages.xml
+++ b/xml/en/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: Linux packages"
          link="/en/linux_packages.html"
          lang="en"
-         rev="97">
+         rev="98">
 
 <section name="Supported distributions and versions" id="distributions">
 
@@ -24,11 +24,6 @@ versions:
 <tr>
 <td width="30%">Version</td>
 <td>Supported Platforms</td>
-</tr>
-
-<tr>
-<td width="30%">7.4+</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
@@ -85,11 +80,6 @@ versions:
 <tr>
 <td width="30%">22.04 “jammy”</td>
 <td>x86_64, aarch64/arm64, s390x</td>
-</tr>
-
-<tr>
-<td width="30%">23.10 “mantic”</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
@@ -180,7 +170,7 @@ versions:
 </para>
 
 <para>
-Packages for RHEL 7 and SLES 12 are built without
+Packages for SLES 12 are built without
 <link doc="docs/http/ngx_http_v3_module.xml">HTTP/3 support</link>
 because OpenSSL used by those doesn't support TLSv1.3.
 </para>

--- a/xml/ru/linux_packages.xml
+++ b/xml/ru/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: пакеты для Linux"
          link="/ru/linux_packages.html"
          lang="ru"
-         rev="97">
+         rev="98">
 
 <section name="Поддерживаемые дистрибутивы и версии" id="distributions">
 
@@ -24,11 +24,6 @@
 <tr>
 <td width="30%">Версия</td>
 <td>Поддерживаемые платформы</td>
-</tr>
-
-<tr>
-<td width="30%">7.4+</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
@@ -85,11 +80,6 @@
 <tr>
 <td width="30%">22.04 “jammy”</td>
 <td>x86_64, aarch64/arm64, s390x</td>
-</tr>
-
-<tr>
-<td width="30%">23.10 “mantic”</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
@@ -180,7 +170,7 @@
 </para>
 
 <para>
-Пакеты для RHEL 7 и SLES 12 собраны без
+Пакеты для SLES 12 собраны без
 <link doc="docs/http/ngx_http_v3_module.xml">поддержки HTTP/3</link>,
 так как OpenSSL, используемая в этих дистрибутивах, не поддерживает TLSv1.3.
 </para>


### PR DESCRIPTION
Namely, removed RHEL 7 and Ubuntu 23.10 due to EOL.