### PR TITLE
Linux packages: removed s390x architecture support.

### DIFF
--- a/xml/en/linux_packages.xml
+++ b/xml/en/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: Linux packages"
          link="/en/linux_packages.html"
          lang="en"
-         rev="98">
+         rev="99">
 
 <section name="Supported distributions and versions" id="distributions">
 
@@ -28,12 +28,12 @@ versions:
 
 <tr>
 <td width="30%">8.x</td>
-<td>x86_64, aarch64/arm64, s390x</td>
+<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
 <td width="30%">9.x</td>
-<td>x86_64, aarch64/arm64, s390x</td>
+<td>x86_64, aarch64/arm64</td>
 </tr>
 
 </table>
@@ -74,12 +74,12 @@ versions:
 
 <tr>
 <td width="30%">20.04 “focal”</td>
-<td>x86_64, aarch64/arm64, s390x</td>
+<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
 <td width="30%">22.04 “jammy”</td>
-<td>x86_64, aarch64/arm64, s390x</td>
+<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>

--- a/xml/ru/linux_packages.xml
+++ b/xml/ru/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: пакеты для Linux"
          link="/ru/linux_packages.html"
          lang="ru"
-         rev="98">
+         rev="99">
 
 <section name="Поддерживаемые дистрибутивы и версии" id="distributions">
 
@@ -28,12 +28,12 @@
 
 <tr>
 <td width="30%">8.x</td>
-<td>x86_64, aarch64/arm64, s390x</td>
+<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
 <td width="30%">9.x</td>
-<td>x86_64, aarch64/arm64, s390x</td>
+<td>x86_64, aarch64/arm64</td>
 </tr>
 
 </table>
@@ -74,12 +74,12 @@
 
 <tr>
 <td width="30%">20.04 “focal”</td>
-<td>x86_64, aarch64/arm64, s390x</td>
+<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
 <td width="30%">22.04 “jammy”</td>
-<td>x86_64, aarch64/arm64, s390x</td>
+<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
The binary packages will no longer be built for that architecture.