### PR TITLE
Update twitter.com links to x.com

### DIFF
--- a/xml/en/community.xml
+++ b/xml/en/community.xml
@@ -7,7 +7,7 @@
 <article name="nginx: community"
          link="/en/community.html"
          lang="en"
-         rev="3">
+         rev="4">
 
 <section name="Community and Governance">
 
@@ -86,7 +86,7 @@ Find the NGINX community here:
 </listitem>
 
 <listitem>
-<link url="https://twitter.com/nginxorg">Twitter</link>
+<link url="https://x.com/nginxorg">X.com</link>
 </listitem>
 
 <listitem>

--- a/xml/menu.xml
+++ b/xml/menu.xml
@@ -32,7 +32,7 @@
 <item href="/en/support.html" lang="en"> 支持 </item>
 <item />
 
-<item href="http://twitter.com/nginxorg"> twitter </item>
+<item href="https://x.com/nginxorg"> x.com </item>
 <item href="https://blog.nginx.org/"> blog </item>
 <item />
 
@@ -84,7 +84,7 @@
 <item href="/en/community.html"> community </item>
 <item />
 
-<item href="http://twitter.com/nginxorg"> twitter </item>
+<item href="https://x.com/nginxorg"> x.com </item>
 <item href="https://blog.nginx.org/"> blog </item>
 <item />
 
@@ -118,7 +118,7 @@
 <item href="/en/support.html" lang="אנגלית"> תמיכה </item>
 <item />
 
-<item href="http://twitter.com/nginxorg"> twitter </item>
+<item href="https://x.com/nginxorg"> x.com </item>
 <item href="https://blog.nginx.org/"> blog </item>
 <item />
 
@@ -153,7 +153,7 @@
 <item href="/en/support.html" lang="en"> サポート </item>
 <item />
 
-<item href="http://twitter.com/nginxorg"> twitter </item>
+<item href="https://x.com/nginxorg"> x.com </item>
 <item href="http://blog.nginx.org/"> blog </item>
 <item />
 
@@ -188,7 +188,7 @@
 <item href="/ru/community.html"> сообщество </item>
 <item />
 
-<item href="http://twitter.com/nginxorg"> twitter </item>
+<item href="https://x.com/nginxorg"> x.com </item>
 <item href="https://blog.nginx.org/"> blog </item>
 <item />
 
@@ -224,7 +224,7 @@
 <item href="/en/support.html" lang="ing"> destek </item>
 <item />
 
-<item href="http://twitter.com/nginxorg"> twitter </item>
+<item href="https://x.com/nginxorg"> x.com </item>
 <item href="https://blog.nginx.org/"> blog </item>
 <item />
 
@@ -259,7 +259,7 @@
 <item href="/it/support.html"> supporto </item>
 <item />
 
-<item href="http://twitter.com/nginxorg"> twitter </item>
+<item href="https://x.com/nginxorg"> x.com </item>
 <item href="https://blog.nginx.org/"> blog </item>
 <item />
 

--- a/xml/ru/community.xml
+++ b/xml/ru/community.xml
@@ -7,7 +7,7 @@
 <article name="nginx: сообщество"
          link="/ru/community.html"
          lang="ru"
-         rev="3">
+         rev="4">
 
 <section name="Сообщество и управление сообществом">
 
@@ -86,7 +86,7 @@ NGINX, следуя своим ценностям, стремится созда
 </listitem>
 
 <listitem>
-<link url="https://twitter.com/nginxorg">Twitter</link>
+<link url="https://x.com/nginxorg">X.com</link>
 </listitem>
 
 <listitem>


### PR DESCRIPTION
Twitter doesn't exist anymore, it has been replaced by X.com, so this patch updates the links to x.com, upgrading them to HTTPS, and changes the "twitter" text to "x.com".