### PR TITLE
Banner: nginx 20 years.

### DIFF
--- a/xml/banner.xml
+++ b/xml/banner.xml
@@ -2,9 +2,9 @@
 
 <banner>
 
-Have you heard?
-<link url="https://nginx.org/en/">nginx</link> has moved to
-<link url="https://github.com/nginx/nginx/">GitHub</link>.
-<link url="https://mailman.nginx.org/pipermail/nginx/2024-September/R7KBUUNTG3B2QAAMPS6M7YDOSVCMOZD7.html">Read more</link>.
+Celebrating <link url="https://github.com/nginx/nginx/commit/0e8348c50">20 years</link>
+of nginx!
+Read about our journey and milestones in the
+<link url="https://blog.nginx.org/blog/celebrating-20-years-of-nginx">latest blog</link>.
 
 </banner>


### PR DESCRIPTION
Will be published on Oct. 04, then reverted back to the current banner.