### PR TITLE
css: h2 wrap instead of scroll.

### DIFF
--- a/css/style_en.css
+++ b/css/style_en.css
@@ -66,7 +66,7 @@ h2 {
     font-size: 2rem;
     line-height: 2.25rem;
     margin: 1rem 0 .5rem 0;
-    overflow-x: scroll;
+    overflow-wrap: break-word;
 }
 
 h4 {

--- a/css/style_ru.css
+++ b/css/style_ru.css
@@ -66,7 +66,7 @@ h2 {
     font-size: 2rem;
     line-height: 2.25rem;
     margin: 1rem 0 .5rem 0;
-    overflow-x: scroll;
+    overflow-wrap: break-word;
 }
 
 h4 {


### PR DESCRIPTION
Previously, h2 would scroll horizontally to accommodate very long page titles, such as ngx_http_random_index_module. This is effective but some browsers always display scrollbars, even when the title does not overflow.

As it is not possible to treat underscore as a wrappable character with the current content generator, we now wrap very long words (mid-word) when necessary. This only applies to the longest of module names (as above).

Closes https://github.com/nginx/nginx.org/issues/49
