### PR TITLE
Linux packages: packaging repo moved to github.

### DIFF
--- a/xml/en/linux_packages.xml
+++ b/xml/en/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: Linux packages"
          link="/en/linux_packages.html"
          lang="en"
-         rev="103">
+         rev="104">
 
 <section name="Supported distributions and versions" id="distributions">
 
@@ -605,11 +605,11 @@ and if so, accept it.
 
 <para>
 Packaging sources can be found in the
-<link url="http://hg.nginx.org/pkg-oss">packaging sources repository</link>.
+<link url="https://github.com/nginx/pkg-oss">packaging sources repository</link>.
 </para>
 
 <para>
-The <literal>default</literal> branch holds packaging sources for the current
+The <literal>master</literal> branch holds packaging sources for the current
 mainline version, while <literal>stable-*</literal> branches contain latest
 sources for stable releases.
 To build binary packages, run <command>make</command> in

--- a/xml/ru/linux_packages.xml
+++ b/xml/ru/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: пакеты для Linux"
          link="/ru/linux_packages.html"
          lang="ru"
-         rev="103">
+         rev="104">
 
 <section name="Поддерживаемые дистрибутивы и версии" id="distributions">
 
@@ -602,11 +602,11 @@ sudo yum install nginx
 
 <para>
 Исходные коды пакетов находятся в соответствующем
-<link url="http://hg.nginx.org/pkg-oss">репозитории</link>.
+<link url="https://github.com/nginx/pkg-oss">репозитории</link>.
 </para>
 
 <para>
-Ветка репозитория <literal>default</literal> содержит исходные коды пакетов для
+Ветка репозитория <literal>master</literal> содержит исходные коды пакетов для
 mainline-версии, в то время как ветки <literal>stable-*</literal> содержат
 исходные коды пакетов для стабильных релизов.
 Для сборки бинарных пакетов запустите <command>make</command> в каталоге


### PR DESCRIPTION
### Proposed changes

Point the packaging repo to github instead of a deprecated mercurial repo.