### PR TITLE
Added Unit releases to news.

### DIFF
--- a/xml/index.xml
+++ b/xml/index.xml
@@ -27,6 +27,13 @@
 <year href="2009.html" year="2009" />
 </years>
 
+<event date="2025-02-26">
+<para>
+<link url="https://unit.nginx.org/">unit-1.34.2</link> bugfix version has been
+<link url="https://unit.nginx.org/news/2025/unit-1.34.2-released/">released</link>.
+</para>
+</event>
+
 <event date="2025-02-05">
 <para>
 <link doc="en/download.xml">nginx-1.26.3</link>
@@ -57,6 +64,22 @@ version has been
 featuring
 <link doc="en/docs/njs/reference.xml" id="njs_api_fs">fs module</link>
 for the <link doc="en/docs/njs/engine.xml">QuickJS</link> engine.
+</para>
+</event>
+
+<event date="2025-01-10">
+<para>
+<link url="https://unit.nginx.org/">unit-1.34.1</link> bugfix version has been
+<link url="https://unit.nginx.org/news/2025/unit-1.34.1-released/">released</link>.
+</para>
+</event>
+
+<event date="2024-12-19">
+<para>
+<link url="https://unit.nginx.org/">unit-1.34.0</link>
+version has been
+<link url="https://unit.nginx.org/news/2024/unit-1.34.0-released/">released</link>,
+featuring initial OpenTelemetry (OTEL) support.
 </para>
 </event>
 
@@ -102,6 +125,15 @@ mainline version has been released.
 version has been
 <link doc="en/docs/njs/changes.xml" id="njs0.8.6">released</link>,
 featuring the <link doc="en/docs/njs/engine.xml">QuickJS</link> engine support.
+</para>
+</event>
+
+<event date="2024-09-18">
+<para>
+<link url="https://unit.nginx.org/">unit-1.33.0</link>
+version has been
+<link url="https://unit.nginx.org/news/2024/unit-1.33.0-released/">released</link>,
+featuring three new configuration options and a CLI tool.
 </para>
 </event>
 


### PR DESCRIPTION
The https://nginx.org/news.html was updated with 2024-2025 Unit releases from https://unit.nginx.org/news/