### PR TITLE
Improved docs on accept_mutex_delay

### DIFF
--- a/xml/en/docs/ngx_core_module.xml
+++ b/xml/en/docs/ngx_core_module.xml
@@ -66,7 +66,7 @@ Prior to version 1.11.3, the default value was <literal>on</literal>.
 <context>events</context>
 
 <para>
-If <link id="accept_mutex"/> is enabled, specifies the maximum time
+If <link id="accept_mutex"/> is enabled, this directive specifies the maximum time
 during which a worker process will try to restart accepting new
 connections if another worker process is currently accepting
 new connections.


### PR DESCRIPTION
### Proposed changes

While reading the docs especially the accept_mutex_delay section the sentence there bugged me quiet a bit. So I just added two words that would make reading that it a bit more easier 
```bash
If [accept_mutex](https://nginx.org/en/docs/ngx_core_module.html#accept_mutex) is enabled, specifies the maximum time during which a worker process will try to restart accepting new connections if another worker process is currently accepting new connections.
```
to
```bash
If [accept_mutex](https://nginx.org/en/docs/ngx_core_module.html#accept_mutex) is enabled, **this directive** specifies the maximum time during which a worker process will try to restart accepting new connections if another worker process is currently accepting new connections.
```
[Part of documentation](https://nginx.org/en/docs/ngx_core_module.html#accept_mutex_delay)

I know this is isnt a big deal but it kinda bugged me a lot while reading it. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
