### PR TITLE
Updated build instructions for QUIC with BoringSSL.

### DIFF
--- a/xml/en/docs/quic.xml
+++ b/xml/en/docs/quic.xml
@@ -61,8 +61,7 @@ Use the following command to configure nginx with
     --with-debug
     --with-http_v3_module
     --with-cc-opt="-I../boringssl/include"
-    --with-ld-opt="-L../boringssl/build/ssl
-                   -L../boringssl/build/crypto"
+    --with-ld-opt="-L../boringssl/build -lstdc++"
 </programlisting>
 </para>
 

--- a/xml/ru/docs/quic.xml
+++ b/xml/ru/docs/quic.xml
@@ -62,8 +62,7 @@
     --with-debug
     --with-http_v3_module
     --with-cc-opt="-I../boringssl/include"
-    --with-ld-opt="-L../boringssl/build/ssl
-                   -L../boringssl/build/crypto"
+    --with-ld-opt="-L../boringssl/build -lstdc++"
 </programlisting>
 </para>
 


### PR DESCRIPTION
See for details:
  https://boringssl.googlesource.com/boringssl/+/c5280615
  https://boringssl.googlesource.com/boringssl/+/5e3ba4c1

The library output location has been originally changed in https://boringssl.googlesource.com/boringssl/+/197b5715 (2023).