### PR TITLE
Linux packages: Actualized the list of supported distributions.

### DIFF
--- a/xml/en/linux_packages.xml
+++ b/xml/en/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: Linux packages"
          link="/en/linux_packages.html"
          lang="en"
-         rev="106">
+         rev="107">
 
 <section name="Supported distributions and versions" id="distributions">
 
@@ -33,6 +33,11 @@ versions:
 
 <tr>
 <td width="30%">9.x</td>
+<td>x86_64, aarch64/arm64</td>
+</tr>
+
+<tr>
+<td width="30%">10.x</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 
@@ -70,11 +75,6 @@ versions:
 <tr>
 <td width="30%">Version</td>
 <td>Supported Platforms</td>
-</tr>
-
-<tr>
-<td width="30%">20.04 “focal”</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
@@ -129,11 +129,6 @@ versions:
 </tr>
 
 <tr>
-<td width="30%">3.18</td>
-<td>x86_64, aarch64/arm64</td>
-</tr>
-
-<tr>
 <td width="30%">3.19</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
@@ -145,6 +140,11 @@ versions:
 
 <tr>
 <td width="30%">3.21</td>
+<td>x86_64, aarch64/arm64</td>
+</tr>
+
+<tr>
+<td width="30%">3.22</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 

--- a/xml/ru/linux_packages.xml
+++ b/xml/ru/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: пакеты для Linux"
          link="/ru/linux_packages.html"
          lang="ru"
-         rev="106">
+         rev="107">
 
 <section name="Поддерживаемые дистрибутивы и версии" id="distributions">
 
@@ -33,6 +33,11 @@
 
 <tr>
 <td width="30%">9.x</td>
+<td>x86_64, aarch64/arm64</td>
+</tr>
+
+<tr>
+<td width="30%">10.x</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 
@@ -70,11 +75,6 @@
 <tr>
 <td width="30%">Версия</td>
 <td>Поддерживаемые платформы</td>
-</tr>
-
-<tr>
-<td width="30%">20.04 “focal”</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
@@ -129,11 +129,6 @@
 </tr>
 
 <tr>
-<td width="30%">3.18</td>
-<td>x86_64, aarch64/arm64</td>
-</tr>
-
-<tr>
 <td width="30%">3.19</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
@@ -145,6 +140,11 @@
 
 <tr>
 <td width="30%">3.21</td>
+<td>x86_64, aarch64/arm64</td>
+</tr>
+
+<tr>
+<td width="30%">3.22</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 


### PR DESCRIPTION
Namely, removed Alpine 3.18 and Ubuntu 20.04 due to EOL and added Alpine 3.22 and RHEL 10.
