### PR TITLE
Actualized the list of OSes supporting TCP keepalive parameters.

### DIFF
--- a/xml/en/docs/http/ngx_http_core_module.xml
+++ b/xml/en/docs/http/ngx_http_core_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_http_core_module"
         link="/en/docs/http/ngx_http_core_module.html"
         lang="en"
-        rev="108">
+        rev="109">
 
 <section id="directives" name="Directives">
 
@@ -1618,8 +1618,9 @@ If it is set to the value “<literal>off</literal>”, the
 Some operating systems support setting of TCP keepalive parameters on
 a per-socket basis using the <c-def>TCP_KEEPIDLE</c-def>,
 <c-def>TCP_KEEPINTVL</c-def>, and <c-def>TCP_KEEPCNT</c-def> socket options.
-On such systems (currently, Linux 2.4+, NetBSD 5+, and
-FreeBSD 9.0-STABLE), they can be configured
+On such systems
+(currently, Linux, NetBSD, Dragonfly, FreeBSD, and macOS),
+they can be configured
 using the <value>keepidle</value>, <value>keepintvl</value>, and
 <value>keepcnt</value> parameters.
 One or two parameters may be omitted, in which case the system default setting

--- a/xml/en/docs/mail/ngx_mail_core_module.xml
+++ b/xml/en/docs/mail/ngx_mail_core_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_mail_core_module"
         link="/en/docs/mail/ngx_mail_core_module.html"
         lang="en"
-        rev="21">
+        rev="22">
 
 <section id="summary">
 
@@ -215,8 +215,9 @@ If it is set to the value “<literal>off</literal>”, the
 Some operating systems support setting of TCP keepalive parameters on
 a per-socket basis using the <c-def>TCP_KEEPIDLE</c-def>,
 <c-def>TCP_KEEPINTVL</c-def>, and <c-def>TCP_KEEPCNT</c-def> socket options.
-On such systems (currently, Linux 2.4+, NetBSD 5+, and
-FreeBSD 9.0-STABLE), they can be configured
+On such systems
+(currently, Linux, NetBSD, Dragonfly, FreeBSD, and macOS),
+they can be configured
 using the <value>keepidle</value>, <value>keepintvl</value>, and
 <value>keepcnt</value> parameters.
 One or two parameters may be omitted, in which case the system default setting

--- a/xml/en/docs/stream/ngx_stream_core_module.xml
+++ b/xml/en/docs/stream/ngx_stream_core_module.xml
@@ -9,7 +9,7 @@
 <module name="Module ngx_stream_core_module"
         link="/en/docs/stream/ngx_stream_core_module.html"
         lang="en"
-        rev="40">
+        rev="41">
 
 <section id="summary">
 
@@ -318,8 +318,9 @@ If it is set to the value “<literal>off</literal>”, the
 Some operating systems support setting of TCP keepalive parameters on
 a per-socket basis using the <c-def>TCP_KEEPIDLE</c-def>,
 <c-def>TCP_KEEPINTVL</c-def>, and <c-def>TCP_KEEPCNT</c-def> socket options.
-On such systems (currently, Linux 2.4+, NetBSD 5+, and
-FreeBSD 9.0-STABLE), they can be configured
+On such systems
+(currently, Linux, NetBSD, Dragonfly, FreeBSD, and macOS),
+they can be configured
 using the <value>keepidle</value>, <value>keepintvl</value>, and
 <value>keepcnt</value> parameters.
 One or two parameters may be omitted, in which case the system default setting

--- a/xml/ru/docs/http/ngx_http_core_module.xml
+++ b/xml/ru/docs/http/ngx_http_core_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_http_core_module"
         link="/ru/docs/http/ngx_http_core_module.html"
         lang="ru"
-        rev="108">
+        rev="109">
 
 <section id="directives" name="Директивы">
 
@@ -1611,8 +1611,8 @@ FreeBSD, DragonFly BSD и macOS, и 511 для других платформ.
 “TCP keepalive” на уровне сокета посредством параметров
 <c-def>TCP_KEEPIDLE</c-def>, <c-def>TCP_KEEPINTVL</c-def> и
 <c-def>TCP_KEEPCNT</c-def>.
-На таких системах (в настоящий момент это Linux 2.4+, NetBSD 5+ и
-FreeBSD 9.0-STABLE)
+На таких системах
+(в настоящий момент это Linux, NetBSD, Dragonfly, FreeBSD и macOS)
 их можно сконфигурировать с помощью параметров <value>keepidle</value>,
 <value>keepintvl</value> и <value>keepcnt</value>.
 Один или два параметра могут быть опущены, в таком случае для

--- a/xml/ru/docs/mail/ngx_mail_core_module.xml
+++ b/xml/ru/docs/mail/ngx_mail_core_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_mail_core_module"
         link="/ru/docs/mail/ngx_mail_core_module.html"
         lang="ru"
-        rev="21">
+        rev="22">
 
 <section id="summary">
 
@@ -217,8 +217,8 @@ FreeBSD, DragonFly BSD и macOS, и 511 для других платформ.
 “TCP keepalive” на уровне сокета посредством параметров
 <c-def>TCP_KEEPIDLE</c-def>, <c-def>TCP_KEEPINTVL</c-def> и
 <c-def>TCP_KEEPCNT</c-def>.
-На таких системах (в настоящий момент это Linux 2.4+, NetBSD 5+ и
-FreeBSD 9.0-STABLE)
+На таких системах
+(в настоящий момент это Linux, NetBSD, Dragonfly, FreeBSD и macOS)
 их можно сконфигурировать с помощью параметров <value>keepidle</value>,
 <value>keepintvl</value> и <value>keepcnt</value>.
 Один или два параметра могут быть опущены, в таком случае для

--- a/xml/ru/docs/stream/ngx_stream_core_module.xml
+++ b/xml/ru/docs/stream/ngx_stream_core_module.xml
@@ -9,7 +9,7 @@
 <module name="Модуль ngx_stream_core_module"
         link="/ru/docs/stream/ngx_stream_core_module.html"
         lang="ru"
-        rev="40">
+        rev="41">
 
 <section id="summary">
 
@@ -320,8 +320,8 @@ FreeBSD, DragonFly BSD и macOS,
 “TCP keepalive” на уровне сокета посредством параметров
 <c-def>TCP_KEEPIDLE</c-def>, <c-def>TCP_KEEPINTVL</c-def> и
 <c-def>TCP_KEEPCNT</c-def>.
-На таких системах (в настоящий момент это Linux 2.4+, NetBSD 5+ и
-FreeBSD 9.0-STABLE)
+На таких системах
+(в настоящий момент это Linux, NetBSD, Dragonfly, FreeBSD и macOS)
 их можно сконфигурировать с помощью параметров <value>keepidle</value>,
 <value>keepintvl</value> и <value>keepcnt</value>.
 Один или два параметра могут быть опущены, в таком случае для


### PR DESCRIPTION
Where here, removed OS history, which is largely outdated, clutters
the list, and barely belongs here.
