### PR TITLE
Linux packages: removed Ubuntu 24.10 due to EOL.

### DIFF
--- a/xml/en/linux_packages.xml
+++ b/xml/en/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: Linux packages"
          link="/en/linux_packages.html"
          lang="en"
-         rev="107">
+         rev="108">
 
 <section name="Supported distributions and versions" id="distributions">
 
@@ -84,11 +84,6 @@ versions:
 
 <tr>
 <td width="30%">24.04 “noble”</td>
-<td>x86_64, aarch64/arm64</td>
-</tr>
-
-<tr>
-<td width="30%">24.10 “oracular”</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 

--- a/xml/ru/linux_packages.xml
+++ b/xml/ru/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: пакеты для Linux"
          link="/ru/linux_packages.html"
          lang="ru"
-         rev="107">
+         rev="108">
 
 <section name="Поддерживаемые дистрибутивы и версии" id="distributions">
 
@@ -84,11 +84,6 @@
 
 <tr>
 <td width="30%">24.04 “noble”</td>
-<td>x86_64, aarch64/arm64</td>
-</tr>
-
-<tr>
-<td width="30%">24.10 “oracular”</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 


### PR DESCRIPTION
Linux packages: removed Ubuntu 24.10 due to EOL.