### PR TITLE
Reverted banner to reference community forum.

### DIFF
--- a/xml/banner.xml
+++ b/xml/banner.xml
@@ -2,7 +2,8 @@
 
 <banner>
 
-The NGINX Team wants to hear from you.
-<link url="https://survey.developernation.net/name/nginx2/branch/main">Take the 2025 NGINX User Survey</link>.
+Join us on the new <link url="https://community.nginx.org">NGINX Community Forum</link>
+to connect with users, discover the latest community activity,
+and troubleshoot issues together.
 
 </banner>


### PR DESCRIPTION
### Proposed changes

The 2025 NGINX survey is closing so the banner needs to be reverted back to reference the NGINX Community Forum.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
