### PR TITLE
HTTP/3 documentation update

### DIFF
--- a/xml/en/docs/configure.xml
+++ b/xml/en/docs/configure.xml
@@ -8,7 +8,7 @@
 <article name="Building nginx from Sources"
          link="/en/docs/configure.html"
          lang="en"
-         rev="24">
+         rev="25">
 
 <section>
 
@@ -245,15 +245,8 @@ This module is not built by default.
 enables building a module that provides support for
 <link doc="http/ngx_http_v3_module.xml">HTTP/3</link>.
 This module is not built by default.
-An SSL library that provides HTTP/3 support
-is recommended to build and run this module, such as
-<link url="https://boringssl.googlesource.com/boringssl">BoringSSL</link>,
-<link url="https://www.libressl.org">LibreSSL</link>, or
-<link url="https://github.com/quictls/openssl">QuicTLS</link>.
-Otherwise, if using the OpenSSL library,
-OpenSSL compatibility layer will be used
-that does not support QUIC
-<link doc="http/ngx_http_ssl_module.xml" id="ssl_early_data">early data</link>.
+The OpenSSL library that provides HTTP/3 support
+is required to build and run this module.
 </tag-desc>
 
 <tag-name>

--- a/xml/en/docs/http/ngx_http_v3_module.xml
+++ b/xml/en/docs/http/ngx_http_v3_module.xml
@@ -21,7 +21,7 @@ experimental support for
 
 <para>
 This module is not built by default, it should be enabled with the
-<link doc="../configure.xml" id="http_v3_module"><literal>--with-http_v3_module</literal></link>
+<literal>--with-http_v3_module</literal>
 configuration parameter.
 <note>
 An SSL library that provides QUIC support

--- a/xml/en/docs/http/ngx_http_v3_module.xml
+++ b/xml/en/docs/http/ngx_http_v3_module.xml
@@ -24,16 +24,19 @@ This module is not built by default, it should be enabled with the
 <literal>--with-http_v3_module</literal>
 configuration parameter.
 <note>
-An SSL library that provides QUIC support
-such as
+This module requires the
+<link url="http://www.openssl.org">OpenSSL</link> library
+version 1.1.1 or higher.
+</note>
+<note>
+0-RTT support requires the
+<link url="http://www.openssl.org">OpenSSL</link> library
+version 3.5.1 or higher.
+Alternatively,
 <link url="https://boringssl.googlesource.com/boringssl">BoringSSL</link>,
 <link url="https://www.libressl.org">LibreSSL</link>, or
 <link url="https://github.com/quictls/openssl">QuicTLS</link>
-is recommended to build and run this module.
-Otherwise,
-when using the <link url="https://openssl.org">OpenSSL</link> library,
-OpenSSL compatibility layer will be used that does not support
-<link doc="ngx_http_ssl_module.xml" id="ssl_early_data">early data</link>.
+libraries can be used to build and run this module.
 </note>
 </para>
 
@@ -44,6 +47,14 @@ OpenSSL compatibility layer will be used that does not support
 
 <para>
 The module is experimental, caveat emptor applies.
+</para>
+
+<para>
+Before version 1.29.1,
+0-RTT support could not be enabled with OpenSSL
+regardless of the
+<link doc="ngx_http_ssl_module.xml" id="ssl_early_data"/>
+directive value.
 </para>
 
 </section>
@@ -76,9 +87,6 @@ http {
     }
 }
 </example>
-Note that accepting HTTP/3 connections over TLS requires
-the TLSv1.3 protocol support, which is available since
-<link url="http://www.openssl.org">OpenSSL</link> version 1.1.1.
 </para>
 
 </section>

--- a/xml/en/docs/http/ngx_http_v3_module.xml
+++ b/xml/en/docs/http/ngx_http_v3_module.xml
@@ -9,7 +9,7 @@
 <module name="Module ngx_http_v3_module"
         link="/en/docs/http/ngx_http_v3_module.html"
         lang="en"
-        rev="2">
+        rev="3">
 
 <section id="summary">
 
@@ -55,6 +55,10 @@ Before version 1.29.1,
 regardless of the
 <link doc="ngx_http_ssl_module.xml" id="ssl_early_data"/>
 directive value.
+</para>
+
+<para>
+The module cannot be built on the Win32 platform.
 </para>
 
 </section>

--- a/xml/en/docs/quic.xml
+++ b/xml/en/docs/quic.xml
@@ -7,7 +7,7 @@
 <article name="Support for QUIC and HTTP/3"
          link="/en/docs/quic.html"
          lang="en"
-         rev="2">
+         rev="3">
 
 <section>
 
@@ -16,15 +16,11 @@ Support for
 <link url="https://datatracker.ietf.org/doc/html/rfc9000">QUIC</link>
 and
 <link url="https://datatracker.ietf.org/doc/html/rfc9114">HTTP/3</link>
-protocols is available since 1.25.0.
-Also, since 1.25.0, the QUIC and HTTP/3 support is available in
+protocols is available since 1.25.0, it is included in
 Linux <link doc="../linux_packages.xml">binary packages</link>.
-</para>
-
-<para>
-<note>
-The QUIC and HTTP/3 support is experimental, caveat emptor applies.
-</note>
+Please refer to the
+<link doc="http/ngx_http_v3_module.xml">ngx_http_v3_module</link>
+documentation.
 </para>
 
 </section>
@@ -38,19 +34,16 @@ Please refer to <link doc="configure.xml"/> for details.
 </para>
 
 <para>
-When configuring nginx, it is possible to enable QUIC and HTTP/3 using the
-<link doc="configure.xml" id="http_v3_module"><literal>--with-http_v3_module</literal></link>
-configuration parameter.
-</para>
-
-<para>
-An SSL library that provides QUIC support is recommended to build nginx, such as
-<link url="https://boringssl.googlesource.com/boringssl">BoringSSL</link>,
-<link url="https://www.libressl.org">LibreSSL</link>, or
-<link url="https://github.com/quictls/openssl">QuicTLS</link>.
+The <link url="https://openssl.org">OpenSSL</link> library
+version 3.5.1 or higher is recommended to build nginx with QUIC support.
 Otherwise, the <link url="https://openssl.org">OpenSSL</link>
 compatibility layer will be used that does not support
 <link doc="http/ngx_http_ssl_module.xml" id="ssl_early_data">early data</link>.
+Alternatively,
+<link url="https://boringssl.googlesource.com/boringssl">BoringSSL</link>,
+<link url="https://www.libressl.org">LibreSSL</link>, or
+<link url="https://github.com/quictls/openssl">QuicTLS</link>
+prebuilt libraries can be used.
 </para>
 
 <para>
@@ -78,7 +71,7 @@ Alternatively, nginx can be configured with
 </para>
 
 <para>
-Alternatively, nginx can be configured with a modern version of
+Alternatively, nginx can be configured with
 <link url="https://www.libressl.org">LibreSSL</link>:
 <programlisting>
 ./configure
@@ -97,7 +90,7 @@ nginx is compiled and installed using <command>make</command>.
 </section>
 
 
-<section id="configuration" name="Configuration">
+<section id="configuration" name="Configuration tips">
 
 <para>
 The <link doc="http/ngx_http_core_module.xml" id="listen"/> directive in
@@ -112,11 +105,6 @@ Along with the <literal>quic</literal> parameter
 it is also possible to specify the
 <link doc="http/ngx_http_core_module.xml" id="reuseport">reuseport</link>
 parameter to make it work properly with multiple workers.
-</para>
-
-<para>
-For the list of directives, see
-<link doc="http/ngx_http_v3_module.xml">ngx_http_v3_module</link>.
 </para>
 
 <para>
@@ -156,38 +144,6 @@ By default,
 is disabled.
 Enable it in case a corresponding network interface is configured
 to support GSO.
-</para>
-
-</section>
-
-
-<section id="example" name="Example Configuration">
-
-<para>
-<example>
-http {
-    log_format quic '$remote_addr - $remote_user [$time_local] '
-                    '"$request" $status $body_bytes_sent '
-                    '"$http_referer" "$http_user_agent" "$http3"';
-
-    access_log logs/access.log quic;
-
-    server {
-        # for better compatibility it's recommended
-        # to use the same port for quic and https
-        listen 8443 quic reuseport;
-        listen 8443 ssl;
-
-        ssl_certificate     certs/example.com.crt;
-        ssl_certificate_key certs/example.com.key;
-
-        location / {
-            # required for browsers to direct them to quic port
-            add_header Alt-Svc 'h3=":8443"; ma=86400';
-        }
-    }
-}
-</example>
 </para>
 
 </section>

--- a/xml/ru/docs/configure.xml
+++ b/xml/ru/docs/configure.xml
@@ -8,7 +8,7 @@
 <article name="Сборка nginx из исходных файлов"
          link="/ru/docs/configure.html"
          lang="ru"
-         rev="24">
+         rev="25">
 
 <section>
 
@@ -243,16 +243,8 @@
 разрешает сборку модуля для работы HTTP-сервера по протоколу
 <link doc="http/ngx_http_v3_module.xml">HTTP/3</link>.
 По умолчанию модуль не собирается.
-Для сборки и работы этого модуля рекомендуется библиотека SSL с поддержкой HTTP/3,
-например
-<link url="https://boringssl.googlesource.com/boringssl">BoringSSL</link>,
-<link url="https://www.libressl.org">LibreSSL</link> или
-<link url="https://github.com/quictls/openssl">QuicTLS</link>.
-Иначе, при использовании библиотеки OpenSSL,
-будет использоваться OpenSSL compatibility layer,
-в котором не поддерживается QUIC
-<link doc="http/ngx_http_ssl_module.xml" id="ssl_early_data">early data</link>.
-
+Для сборки и работы этого модуля
+нужна библиотека OpenSSL с поддержкой HTTP/3.
 </tag-desc>
 
 <tag-name>

--- a/xml/ru/docs/http/ngx_http_v3_module.xml
+++ b/xml/ru/docs/http/ngx_http_v3_module.xml
@@ -9,7 +9,7 @@
 <module name="Модуль ngx_http_v3_module"
         link="/ru/docs/http/ngx_http_v3_module.html"
         lang="ru"
-        rev="2">
+        rev="3">
 
 <section id="summary">
 
@@ -52,6 +52,10 @@
 независимо от
 значения директивы
 <link doc="ngx_http_ssl_module.xml" id="ssl_early_data"/>.
+</para>
+
+<para>
+Сборка модуля не поддерживается на платформе Win32.
 </para>
 
 </section>

--- a/xml/ru/docs/http/ngx_http_v3_module.xml
+++ b/xml/ru/docs/http/ngx_http_v3_module.xml
@@ -24,16 +24,16 @@
 разрешить с помощью конфигурационного параметра
 <literal>--with-http_v3_module</literal>.
 <note>
-Для сборки и работы этого модуля рекомендуется использовать
-библиотеку SSL с поддержкой QUIC, например
+Для сборки и работы этого модуля нужна библиотека
+<link url="http://www.openssl.org">OpenSSL</link> версии 1.1.1 или выше.
+</note>
+<note>
+Для поддержки 0-RTT нужна библиотека
+<link url="http://www.openssl.org">OpenSSL</link> версии 3.5.1 или выше.
+Также возможно использование библиотек
 <link url="https://boringssl.googlesource.com/boringssl">BoringSSL</link>,
 <link url="https://www.libressl.org">LibreSSL</link>,
 <link url="https://github.com/quictls/openssl">QuicTLS</link>.
-Иначе,
-при использовании библиотеки <link url="https://openssl.org">OpenSSL</link>,
-будет использоваться OpenSSL compatibility layer,
-в котором не поддерживается
-<link doc="ngx_http_ssl_module.xml" id="ssl_early_data">early data</link>.
 </note>
 </para>
 
@@ -44,6 +44,14 @@
 
 <para>
 Модуль экспериментальный, поэтому возможно всё.
+</para>
+
+<para>
+До версии 1.29.1
+поддержка 0-RTT не могла быть разрешена при использовании OpenSSL
+независимо от
+значения директивы
+<link doc="ngx_http_ssl_module.xml" id="ssl_early_data"/>.
 </para>
 
 </section>
@@ -76,9 +84,6 @@ http {
     }
 }
 </example>
-Чтобы принимать HTTP/3-соединения по TLS, необходимо
-наличие поддержки протокола TLSv1.3, появившейся в
-<link url="http://www.openssl.org">OpenSSL</link> версии 1.1.1.
 </para>
 
 </section>

--- a/xml/ru/docs/http/ngx_http_v3_module.xml
+++ b/xml/ru/docs/http/ngx_http_v3_module.xml
@@ -22,7 +22,7 @@
 <para>
 По умолчанию этот модуль не собирается, его сборку необходимо
 разрешить с помощью конфигурационного параметра
-<link doc="../configure.xml" id="http_v3_module"><literal>--with-http_v3_module</literal></link>.
+<literal>--with-http_v3_module</literal>.
 <note>
 Для сборки и работы этого модуля рекомендуется использовать
 библиотеку SSL с поддержкой QUIC, например

--- a/xml/ru/docs/quic.xml
+++ b/xml/ru/docs/quic.xml
@@ -7,7 +7,7 @@
 <article name="Поддержка QUIC и HTTP/3"
          link="/ru/docs/quic.html"
          lang="ru"
-         rev="2">
+         rev="3">
 
 <section>
 
@@ -16,15 +16,10 @@
 <link url="https://datatracker.ietf.org/doc/html/rfc9000">QUIC</link>
 и
 <link url="https://datatracker.ietf.org/doc/html/rfc9114">HTTP/3</link>
-доступна начиная с версии 1.25.0.
-Также, начиная с 1.25.0, поддержка доступна в
-<link doc="../linux_packages.xml">готовых пакетах</link> для Linux.
-</para>
-
-<para>
-<note>
-Поддержка QUIC и HTTP/3 экспериментальная, поэтому возможно всё.
-</note>
+доступна начиная с версии 1.25.0, она включена в
+<link doc="../linux_packages.xml">бинарных пакетах</link> для Linux.
+Подробнее см. документацию к модулю
+<link doc="http/ngx_http_v3_module.xml">ngx_http_v3_module</link>.
 </para>
 
 </section>
@@ -38,19 +33,14 @@
 </para>
 
 <para>
-Во время сборки nginx можно включить QUIC и HTTP/3
-при помощи конфигурационного параметра
-<link doc="configure.xml" id="http_v3_module"><literal>--with-http_v3_module</literal></link>.
-</para>
-
-<para>
-Для сборки nginx рекомендуется библиотека SSL с поддержкой QUIC, например
+Для сборки nginx с поддержкой QUIC рекомендуется библиотека
+<link url="https://openssl.org">OpenSSL</link> версии 3.5.1 или выше.
+Иначе будет использоваться OpenSSL compatibility layer без поддержки TLS
+<link doc="http/ngx_http_ssl_module.xml" id="ssl_early_data">early data</link>.
+Также возможно использование предварительно собранной библиотеки
 <link url="https://boringssl.googlesource.com/boringssl">BoringSSL</link>,
 <link url="https://www.libressl.org">LibreSSL</link> или
 <link url="https://github.com/quictls/openssl">QuicTLS</link>.
-Иначе, при использовании библиотеки <link url="https://openssl.org">OpenSSL</link>,
-будет использоваться OpenSSL compatibility layer, в котором не поддерживается
-<link doc="http/ngx_http_ssl_module.xml" id="ssl_early_data">early data</link>.
 </para>
 
 <para>
@@ -79,7 +69,7 @@
 </para>
 
 <para>
-Кроме того, можно сконфигурировать nginx с современной версией
+Кроме того, можно сконфигурировать nginx с
 <link url="https://www.libressl.org">LibreSSL</link>:
 <programlisting>
 ./configure
@@ -99,7 +89,7 @@ nginx компилируется и устанавливается с помощ
 </section>
 
 
-<section id="configuration" name="Конфигурация">
+<section id="configuration" name="Советы по настройке">
 
 <para>
 В директиве <link doc="http/ngx_http_core_module.xml" id="listen"/>
@@ -114,11 +104,6 @@ nginx компилируется и устанавливается с помощ
 можно также указать параметр
 <link doc="http/ngx_http_core_module.xml" id="reuseport">reuseport</link>
 для правильной работы с несколькими рабочими процессами.
-</para>
-
-<para>
-Список директив см. в модуле
-<link doc="http/ngx_http_v3_module.xml">ngx_http_v3_module</link>.
 </para>
 
 <para>
@@ -158,38 +143,6 @@ quic_host_key &lt;filename&gt;;
 выключена.
 Включите, если настроен соответствующий сетевой интерфейс,
 поддерживающий GSO.
-</para>
-
-</section>
-
-
-<section id="example" name="Пример конфигурации">
-
-<para>
-<example>
-http {
-    log_format quic '$remote_addr - $remote_user [$time_local] '
-                    '"$request" $status $body_bytes_sent '
-                    '"$http_referer" "$http_user_agent" "$http3"';
-
-    access_log logs/access.log quic;
-
-    server {
-        # для лучшей совместимости рекомендуется
-        # использовать один порт для quic и https
-        listen 8443 quic reuseport;
-        listen 8443 ssl;
-
-        ssl_certificate     certs/example.com.crt;
-        ssl_certificate_key certs/example.com.key;
-
-        location / {
-            # для перенаправления браузеров в quic-порт
-            add_header Alt-Svc 'h3=":8443"; ma=86400';
-        }
-    }
-}
-</example>
 </para>
 
 </section>


### PR DESCRIPTION
Some lifting and deduplication in face of upcoming nginx 1.29.1 release with OpenSSL QUIC 0-RTT support.