### PR TITLE
Fix for css relative path

### DIFF
--- a/xsls/style.xsls
+++ b/xsls/style.xsls
@@ -14,10 +14,7 @@ X:template style (lang) {
       X:text{stylesheet}
     }
     X:attribute "href" {
-      X:if "substring-after($DIRNAME, '/') or $LINK = '404.html'" {
-          !{ concat($ROOT, '/') }
-      }
-      !{ concat('css/style_', $lang, '.css') }
+      !{ concat('/css/style_', $lang, '.css') }
     }
     !!;
     </link>

--- a/xslt/style.xslt
+++ b/xslt/style.xslt
@@ -15,10 +15,7 @@
       <xsl:text>stylesheet</xsl:text>
     </xsl:attribute>
     <xsl:attribute name="href">
-      <xsl:if test="substring-after($DIRNAME, '/') or $LINK = '404.html'">
-          <xsl:value-of select=" concat($ROOT, '/') "/>
-      </xsl:if>
-      <xsl:value-of select=" concat('css/style_', $lang, '.css') "/>
+      <xsl:value-of select=" concat('/css/style_', $lang, '.css') "/>
     </xsl:attribute>
     <xsl:apply-templates/>
     </link>


### PR DESCRIPTION
Uses absolute path for css
Maintains dynamic $lang usage
Fixes issues with `//` in urls and 404 page css

Discovered via https://nginx.org/en/docs//http/ngx_http_acme_module.html search result. Note `//` in url.