### PR TITLE
Added a hint about early_hints in the http2_push directive.

### DIFF
--- a/xml/en/docs/http/ngx_http_v2_module.xml
+++ b/xml/en/docs/http/ngx_http_v2_module.xml
@@ -9,7 +9,7 @@
 <module name="Module ngx_http_v2_module"
         link="/en/docs/http/ngx_http_v2_module.html"
         lang="en"
-        rev="18">
+        rev="19">
 
 <section id="summary">
 
@@ -285,6 +285,8 @@ could result in excessive memory usage and not recommended.
 <para>
 <note>
 This directive is obsolete since version 1.25.1.
+The <link doc="ngx_http_core_module.xml" id="early_hints"/>
+directive can be used instead.
 </note>
 </para>
 

--- a/xml/ru/docs/http/ngx_http_v2_module.xml
+++ b/xml/ru/docs/http/ngx_http_v2_module.xml
@@ -9,7 +9,7 @@
 <module name="Модуль ngx_http_v2_module"
         link="/ru/docs/http/ngx_http_v2_module.html"
         lang="ru"
-        rev="18">
+        rev="19">
 
 <section id="summary">
 
@@ -285,6 +285,8 @@ server {
 <para>
 <note>
 Эта директива устарела начиная с версии 1.25.1.
+Вместо неё можно использовать директиву
+<link doc="ngx_http_core_module.xml" id="early_hints"/>.
 </note>
 </para>
 


### PR DESCRIPTION
It's an alternative mechanism to migrate from obsolete HTTP/2 server push.
