### PR TITLE
feat: Clarifies CRL format

### DIFF
--- a/xml/en/docs/http/ngx_http_grpc_module.xml
+++ b/xml/en/docs/http/ngx_http_grpc_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_http_grpc_module"
         link="/en/docs/http/ngx_http_grpc_module.html"
         lang="en"
-        rev="16">
+        rev="17">
 
 <section id="summary">
 
@@ -784,6 +784,8 @@ might result in unexpected behavior.
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to <link id="grpc_ssl_verify">verify</link>
 the certificate of the gRPC SSL server.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/en/docs/http/ngx_http_oidc_module.xml
+++ b/xml/en/docs/http/ngx_http_oidc_module.xml
@@ -387,6 +387,8 @@ Sets a timeout after which the session is deleted, unless it was
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to verify
 the certificates of the OpenID Provider endpoints.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/en/docs/http/ngx_http_proxy_module.xml
+++ b/xml/en/docs/http/ngx_http_proxy_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_http_proxy_module"
         link="/en/docs/http/ngx_http_proxy_module.html"
         lang="en"
-        rev="86">
+        rev="87">
 
 <section id="summary">
 
@@ -2297,6 +2297,8 @@ might result in unexpected behavior.
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to <link id="proxy_ssl_verify">verify</link>
 the certificate of the proxied HTTPS server.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/en/docs/http/ngx_http_ssl_module.xml
+++ b/xml/en/docs/http/ngx_http_ssl_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_http_ssl_module"
         link="/en/docs/http/ngx_http_ssl_module.html"
         lang="en"
-        rev="73">
+        rev="74">
 
 <section id="summary">
 
@@ -453,6 +453,8 @@ might result in unexpected behavior.
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to <link id="ssl_verify_client">verify</link>
 client certificates.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/en/docs/http/ngx_http_uwsgi_module.xml
+++ b/xml/en/docs/http/ngx_http_uwsgi_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_http_uwsgi_module"
         link="/en/docs/http/ngx_http_uwsgi_module.html"
         lang="en"
-        rev="57">
+        rev="58">
 
 <section id="summary">
 
@@ -1683,6 +1683,8 @@ might result in unexpected behavior.
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to <link id="uwsgi_ssl_verify">verify</link>
 the certificate of the secured uwsgi server.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/en/docs/mail/ngx_mail_ssl_module.xml
+++ b/xml/en/docs/mail/ngx_mail_ssl_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_mail_ssl_module"
         link="/en/docs/mail/ngx_mail_ssl_module.html"
         lang="en"
-        rev="33">
+        rev="34">
 
 <section id="summary">
 
@@ -324,6 +324,8 @@ might result in unexpected behavior.
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to <link id="ssl_verify_client">verify</link>
 client certificates.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/en/docs/ngx_mgmt_module.xml
+++ b/xml/en/docs/ngx_mgmt_module.xml
@@ -240,6 +240,8 @@ See <link doc="http/ngx_http_core_module.xml" id="resolver"/> for details.
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to <link id="ssl_verify">verify</link>
 the certificate of the usage reporting endpoint.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/en/docs/stream/ngx_stream_proxy_module.xml
+++ b/xml/en/docs/stream/ngx_stream_proxy_module.xml
@@ -9,7 +9,7 @@
 <module name="Module ngx_stream_proxy_module"
         link="/en/docs/stream/ngx_stream_proxy_module.html"
         lang="en"
-        rev="37">
+        rev="38">
 
 <section id="summary">
 
@@ -595,6 +595,8 @@ might result in unexpected behavior.
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to <link id="proxy_ssl_verify">verify</link>
 the certificate of the proxied server.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/en/docs/stream/ngx_stream_ssl_module.xml
+++ b/xml/en/docs/stream/ngx_stream_ssl_module.xml
@@ -9,7 +9,7 @@
 <module name="Module ngx_stream_ssl_module"
         link="/en/docs/stream/ngx_stream_ssl_module.html"
         lang="en"
-        rev="46">
+        rev="47">
 
 <section id="summary">
 
@@ -428,6 +428,8 @@ might result in unexpected behavior.
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to <link id="ssl_verify_client">verify</link>
 client certificates.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/en/docs/stream/ngx_stream_zone_sync_module.xml
+++ b/xml/en/docs/stream/ngx_stream_zone_sync_module.xml
@@ -365,6 +365,8 @@ might result in unexpected behavior.
 Specifies a <value>file</value> with revoked certificates (CRL)
 in the PEM format used to <link id="zone_sync_ssl_verify">verify</link>
 the certificate of another cluster server.
+When using intermediate certificates, their CRLs should be
+specified in the same file.
 </para>
 
 </directive>

--- a/xml/ru/docs/http/ngx_http_grpc_module.xml
+++ b/xml/ru/docs/http/ngx_http_grpc_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_http_grpc_module"
         link="/ru/docs/http/ngx_http_grpc_module.html"
         lang="ru"
-        rev="16">
+        rev="17">
 
 <section id="summary">
 
@@ -782,6 +782,8 @@ OpenSSL
 Указывает <value>файл</value> с отозванными сертификатами (CRL)
 в формате PEM, используемыми при <link id="proxy_ssl_verify">проверке</link>
 сертификата gRPC SSL-сервера.
+Если используются промежуточные сертификаты,
+их списки CRL должны находиться в этом же файле.
 </para>
 
 </directive>

--- a/xml/ru/docs/http/ngx_http_proxy_module.xml
+++ b/xml/ru/docs/http/ngx_http_proxy_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_http_proxy_module"
         link="/ru/docs/http/ngx_http_proxy_module.html"
         lang="ru"
-        rev="86">
+        rev="87">
 
 <section id="summary">
 
@@ -2297,6 +2297,8 @@ OpenSSL
 Указывает <value>файл</value> с отозванными сертификатами (CRL)
 в формате PEM, используемыми при <link id="proxy_ssl_verify">проверке</link>
 сертификата проксируемого HTTPS-сервера.
+Если используются промежуточные сертификаты,
+их списки CRL должны находиться в этом же файле.
 </para>
 
 </directive>

--- a/xml/ru/docs/http/ngx_http_ssl_module.xml
+++ b/xml/ru/docs/http/ngx_http_ssl_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_http_ssl_module"
         link="/ru/docs/http/ngx_http_ssl_module.html"
         lang="ru"
-        rev="73">
+        rev="74">
 
 <section id="summary">
 
@@ -455,6 +455,8 @@ ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256;
 Указывает <value>файл</value> с отозванными сертификатами (CRL)
 в формате PEM, используемыми для
 <link id="ssl_verify_client">проверки</link> клиентских сертификатов.
+Если используются промежуточные сертификаты,
+их списки CRL должны находиться в этом же файле.
 </para>
 
 </directive>

--- a/xml/ru/docs/http/ngx_http_uwsgi_module.xml
+++ b/xml/ru/docs/http/ngx_http_uwsgi_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_http_uwsgi_module"
         link="/ru/docs/http/ngx_http_uwsgi_module.html"
         lang="ru"
-        rev="57">
+        rev="58">
 
 <section id="summary">
 
@@ -1679,6 +1679,8 @@ OpenSSL
 Указывает <value>файл</value> с отозванными сертификатами (CRL)
 в формате PEM, используемыми при <link id="uwsgi_ssl_verify">проверке</link>
 сертификата suwsgi-сервера.
+Если используются промежуточные сертификаты,
+их списки CRL должны находиться в этом же файле.
 </para>
 
 </directive>

--- a/xml/ru/docs/mail/ngx_mail_ssl_module.xml
+++ b/xml/ru/docs/mail/ngx_mail_ssl_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_mail_ssl_module"
         link="/ru/docs/mail/ngx_mail_ssl_module.html"
         lang="ru"
-        rev="33">
+        rev="34">
 
 <section id="summary">
 
@@ -325,6 +325,8 @@ ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256;
 Указывает <value>файл</value> с отозванными сертификатами (CRL)
 в формате PEM, используемыми для
 <link id="ssl_verify_client">проверки</link> клиентских сертификатов.
+Если используются промежуточные сертификаты,
+их списки CRL должны находиться в этом же файле.
 </para>
 
 </directive>

--- a/xml/ru/docs/stream/ngx_stream_proxy_module.xml
+++ b/xml/ru/docs/stream/ngx_stream_proxy_module.xml
@@ -9,7 +9,7 @@
 <module name="Модуль ngx_stream_proxy_module"
         link="/ru/docs/stream/ngx_stream_proxy_module.html"
         lang="ru"
-        rev="37">
+        rev="38">
 
 <section id="summary">
 
@@ -593,6 +593,8 @@ OpenSSL
 Указывает <value>файл</value> с отозванными сертификатами (CRL)
 в формате PEM, используемыми при <link id="proxy_ssl_verify">проверке</link>
 сертификата проксируемого сервера.
+Если используются промежуточные сертификаты,
+их списки CRL должны находиться в этом же файле.
 </para>
 
 </directive>

--- a/xml/ru/docs/stream/ngx_stream_ssl_module.xml
+++ b/xml/ru/docs/stream/ngx_stream_ssl_module.xml
@@ -9,7 +9,7 @@
 <module name="Модуль ngx_stream_ssl_module"
         link="/ru/docs/stream/ngx_stream_ssl_module.html"
         lang="ru"
-        rev="46">
+        rev="47">
 
 <section id="summary">
 
@@ -430,6 +430,8 @@ ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256;
 Указывает <value>файл</value> с отозванными сертификатами (CRL)
 в формате PEM, используемыми для
 <link id="ssl_verify_client">проверки</link> клиентских сертификатов.
+Если используются промежуточные сертификаты,
+их списки CRL должны находиться в этом же файле.
 </para>
 
 </directive>


### PR DESCRIPTION
### Proposed changes

closes #187

The [`ssl_crl` documentation](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_crl) does not mention that a revocation list is required for every certificate in the certificate chain, which can cause confusion when using intermediate CAs. [This forum post](https://community.nginx.org/t/client-ssl-certificate-verify-error-3-unable-to-get-certificate-crl-while-reading-client-request-headers/2157), [this ticket](https://trac.nginx.org/nginx/ticket/344#no1) and [this stackoverflow](https://stackoverflow.com/questions/17086934/nginx-unable-to-get-certificate-crl) that specify this requirement, but it seems like it would convenient to have it more visible in the official documentation.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
