### PR TITLE
Docs: document ms suffix for cache_valid directives.

### DIFF
--- a/xml/en/docs/http/ngx_http_fastcgi_module.xml
+++ b/xml/en/docs/http/ngx_http_fastcgi_module.xml
@@ -787,6 +787,11 @@ and 1 minute for responses with code 404.
 </para>
 
 <para>
+The <value>time</value> parameter accepts an optional
+<literal>ms</literal> suffix for millisecond precision (e.g. <literal>100ms</literal>).
+</para>
+
+<para>
 If only caching <value>time</value> is specified
 <example>
 fastcgi_cache_valid 5m;

--- a/xml/en/docs/http/ngx_http_proxy_module.xml
+++ b/xml/en/docs/http/ngx_http_proxy_module.xml
@@ -805,6 +805,11 @@ and 1 minute for responses with code 404.
 </para>
 
 <para>
+The <value>time</value> parameter accepts an optional
+<literal>ms</literal> suffix for millisecond precision (e.g. <literal>100ms</literal>).
+</para>
+
+<para>
 If only caching <value>time</value> is specified
 <example>
 proxy_cache_valid 5m;

--- a/xml/en/docs/http/ngx_http_scgi_module.xml
+++ b/xml/en/docs/http/ngx_http_scgi_module.xml
@@ -778,6 +778,11 @@ and 1 minute for responses with code 404.
 </para>
 
 <para>
+The <value>time</value> parameter accepts an optional
+<literal>ms</literal> suffix for millisecond precision (e.g. <literal>100ms</literal>).
+</para>
+
+<para>
 If only caching <value>time</value> is specified
 <example>
 scgi_cache_valid 5m;

--- a/xml/en/docs/http/ngx_http_uwsgi_module.xml
+++ b/xml/en/docs/http/ngx_http_uwsgi_module.xml
@@ -778,6 +778,11 @@ and 1 minute for responses with code 404.
 </para>
 
 <para>
+The <value>time</value> parameter accepts an optional
+<literal>ms</literal> suffix for millisecond precision (e.g. <literal>100ms</literal>).
+</para>
+
+<para>
 If only caching <value>time</value> is specified
 <example>
 uwsgi_cache_valid 5m;


### PR DESCRIPTION
Add a note that proxy_cache_valid, fastcgi_cache_valid, scgi_cache_valid, and uwsgi_cache_valid accept an optional ms suffix for millisecond precision (e.g. 100ms).
Ref: nginx/nginx#1156

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR's description or commit message.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
