### PR TITLE
Linux packages: removed Alpine 3.20 due to EOL.

### DIFF
--- a/xml/en/linux_packages.xml
+++ b/xml/en/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: Linux packages"
          link="/en/linux_packages.html"
          lang="en"
-         rev="114">
+         rev="115">
 
 <section name="Supported distributions and versions" id="distributions">
 
@@ -136,11 +136,6 @@ versions:
 <tr>
 <td width="30%">Version</td>
 <td>Supported platforms</td>
-</tr>
-
-<tr>
-<td width="30%">3.20</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>

--- a/xml/ru/linux_packages.xml
+++ b/xml/ru/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: пакеты для Linux"
          link="/ru/linux_packages.html"
          lang="ru"
-         rev="114">
+         rev="115">
 
 <section name="Поддерживаемые дистрибутивы и версии" id="distributions">
 
@@ -136,11 +136,6 @@
 <tr>
 <td width="30%">Версия</td>
 <td>Поддерживаемые платформы</td>
-</tr>
-
-<tr>
-<td width="30%">3.20</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
### Proposed changes

This PR removes EOL distros.