### PR TITLE
Document that directio does not apply to cached files

### DIFF
--- a/xml/en/docs/http/ngx_http_core_module.xml
+++ b/xml/en/docs/http/ngx_http_core_module.xml
@@ -522,7 +522,9 @@ the <c-def>O_DIRECT</c-def> flag (FreeBSD, Linux),
 the <c-def>F_NOCACHE</c-def> flag (macOS),
 or the <c-func>directio</c-func> function (Solaris),
 when reading files that are larger than or equal to
-the specified <value>size</value>.
+the specified <value>size</value>
+(does not apply to files served from the
+<link doc="ngx_http_proxy_module.xml" id="proxy_cache">proxy cache</link>).
 The directive automatically disables (0.7.15) the use of
 <link id="sendfile"/>
 for a given request.


### PR DESCRIPTION
`directio` only works for static content in Nginx. It's by design. 
So everything we serve from disk cache passes through the page cache and always has.

## Motivation

People routinely assume directio applies to cache files, which it currently doesn't. They enable it expecting a decline in page cache pressure or memory pressure and are confused to see no change at all.

Related: nginx/nginx#654. freenginx has since added it — see [freenginx 306b71004f29](https://github.com/freenginx/nginx/commit/306b71004f298a2d54521426dc6ac4e358e1d5ce) ("Cache: directio support when reading cache files") and the follow-up [6afd081c554e](https://github.com/freenginx/nginx/commit/6afd081c554e5b00543291e868911a17c0e194db) ("Open file cache: correct directio handling with threads").