### PR TITLE
Linux packages: Actualized the list of supported distributions.

### DIFF
--- a/xml/en/linux_packages.xml
+++ b/xml/en/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: Linux packages"
          link="/en/linux_packages.html"
          lang="en"
-         rev="115">
+         rev="116">
 
 <section name="Supported distributions and versions" id="distributions">
 
@@ -93,12 +93,12 @@ versions:
 </tr>
 
 <tr>
-<td width="30%">25.04 “plucky”</td>
+<td width="30%">25.10 “questing”</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
-<td width="30%">25.10 “questing”</td>
+<td width="30%">26.04 “resolute”</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 

--- a/xml/ru/linux_packages.xml
+++ b/xml/ru/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: пакеты для Linux"
          link="/ru/linux_packages.html"
          lang="ru"
-         rev="115">
+         rev="116">
 
 <section name="Поддерживаемые дистрибутивы и версии" id="distributions">
 
@@ -93,12 +93,12 @@
 </tr>
 
 <tr>
-<td width="30%">25.04 “plucky”</td>
+<td width="30%">25.10 “questing”</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>
-<td width="30%">25.10 “questing”</td>
+<td width="30%">26.04 “resolute”</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
 


### PR DESCRIPTION
Namely, removed Ubuntu 25.04 due to EOL and added Ubuntu 26.04.
