### PR TITLE
Documented the "--without-http_tunnel_module" configure option.

### DIFF
--- a/xml/en/docs/configure.xml
+++ b/xml/en/docs/configure.xml
@@ -8,7 +8,7 @@
 <article name="Building nginx from Sources"
          link="/en/docs/configure.html"
          lang="en"
-         rev="26">
+         rev="27">
 
 <section>
 
@@ -619,6 +619,16 @@ module that passes requests to an SCGI server.
 disables building the
 <link doc="http/ngx_http_grpc_module.xml">ngx_http_grpc_module</link>
 module that passes requests to a gRPC server.
+</tag-desc>
+
+<tag-name>
+<literal>--without-http_tunnel_module</literal>
+</tag-name>
+<tag-desc>
+disables building the
+<link doc="http/ngx_http_tunnel_module.xml">ngx_http_tunnel_module</link>
+module that handles HTTP/1.1 CONNECT requests
+and establishes an end-to-end virtual connection.
 </tag-desc>
 
 <tag-name>

--- a/xml/ru/docs/configure.xml
+++ b/xml/ru/docs/configure.xml
@@ -8,7 +8,7 @@
 <article name="Сборка nginx из исходных файлов"
          link="/ru/docs/configure.html"
          lang="ru"
-         rev="26">
+         rev="27">
 
 <section>
 
@@ -613,6 +613,16 @@ HTTP-сервера.
 запрещает сборку модуля
 <link doc="http/ngx_http_grpc_module.xml">ngx_http_grpc_module</link>,
 позволяющего передавать запросы gRPC-серверу.
+</tag-desc>
+
+<tag-name>
+<literal>--without-http_tunnel_module</literal>
+</tag-name>
+<tag-desc>
+запрещает сборку модуля
+<link doc="http/ngx_http_tunnel_module.xml">ngx_http_tunnel_module</link>,
+позволяющего обрабатывать запросы HTTP/1.1 CONNECT
+для установки сквозного виртуального соединения с другим сервером.
 </tag-desc>
 
 <tag-name>


### PR DESCRIPTION
### Proposed changes

The `--without-http_tunnel_module` option for the `configure` script was declared in [`nginx/auto/options`](https://github.com/nginx/nginx/blob/e8053c867f9ab14f323e3019ccab585d857abb66/auto/options#L518) but not documented. This PR adds it to the configure options documentation page.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
