### PR TITLE
Security warnings

### DIFF
--- a/xml/en/docs/http/ngx_http_fastcgi_module.xml
+++ b/xml/en/docs/http/ngx_http_fastcgi_module.xml
@@ -17,6 +17,13 @@
 <para>
 The <literal>ngx_http_fastcgi_module</literal> module allows passing
 requests to a FastCGI server.
+
+Warning: This module assumes that the server it passes requests
+to is trusted.  It is not to be used with untrusted FastCGI servers.
+
+If possible, using an AF_UNIX socket to connect to the FastCGI server
+is recommended, as it is faster and subject to filesystem access
+controls.
 </para>
 
 </section>

--- a/xml/en/docs/http/ngx_http_headers_module.xml
+++ b/xml/en/docs/http/ngx_http_headers_module.xml
@@ -131,6 +131,16 @@ be inherited in all nested levels recursively unless redefined later.
 Adds the specified field to the end of a response provided that
 the response code equals 200, 201, 206, 301, 302, 303, 307, or 308.
 Parameter value can contain variables.
+
+Warning: If you use variables in the parameter value, you must ensure
+that they are ones that will never contain carriage return, newline,
+or NUL characters.  Failure to ensure this will result in a severe
+vulnerability known as HTTP response splitting.
+
+$uri and the $arg_* variables can contain newlines and must not be used.
+$http_* and $request_uri will never contain newlines.
+
+NGINX does not prevent you from setting headers that you should not.
 </para>
 
 <para id="add_trailer_default_inherit">

--- a/xml/en/docs/http/ngx_http_proxy_module.xml
+++ b/xml/en/docs/http/ngx_http_proxy_module.xml
@@ -2027,6 +2027,22 @@ The <value>value</value> can contain text, variables, and their combinations.
 These directives are inherited from the previous configuration level
 if and only if there are no <literal>proxy_set_header</literal> directives
 defined on the current level.
+
+Warning: If you use variables in the <value>value</value>, you must ensure
+they must never contain newlines, carriage returns, or NUL bytes.  Otherwise,
+you will be exposed to a severe security vulnerability known as HTTP request
+smuggling.
+
+$uri and the $arg_* variables can contain newlines and must not be used.
+$http_* and $request_uri will never contain newlines.
+
+If possible, you should use <literal>proxy_http_version 2;</literal>,
+which uses HTTP/2 to connect to the backend.  HTTP/2 contains built-in
+protections against request smuggling attacks.
+
+Setting <literal>Transfer-Encoding</literal> or
+<literal>Content-Length</literal> is not supported and will cause
+corrupt requests to be sent to upstream servers.
 </para>
 
 <para>

--- a/xml/en/docs/http/ngx_http_proxy_module.xml
+++ b/xml/en/docs/http/ngx_http_proxy_module.xml
@@ -17,6 +17,19 @@
 <para>
 The <literal>ngx_http_proxy_module</literal> module allows passing
 requests to another server.
+
+Warning: This module assumes that the server it passes requests
+to is trusted.  It is not to be used with untrusted backend
+servers.
+
+Due to a <link url="https://github.com/nginx/nginx/issues/1427">bug</link>
+in NGINX's handling of HTTP 1xx responses, this applies even if
+all X-Accel headers are ignored.  It even applies if there is
+a trusted reverse proxy between NGINX and the backend server.
+
+Once the bug is fixed, a third-party intermediate reverse proxy that strips
+X-Accel headers and ensures that all responses are well-formed will be
+sufficient.
 </para>
 
 </section>

--- a/xml/en/docs/http/ngx_http_scgi_module.xml
+++ b/xml/en/docs/http/ngx_http_scgi_module.xml
@@ -17,6 +17,13 @@
 <para>
 The <literal>ngx_http_scgi_module</literal> module allows passing
 requests to an SCGI server.
+
+Warning: This module assumes that the server it passes requests
+to is trusted.  It is not to be used with untrusted SCGI servers.
+
+If possible, using an AF_UNIX socket to connect to the SCGI server
+is recommended, as it is faster and subject to filesystem access
+controls.
 </para>
 
 </section>

--- a/xml/en/docs/http/ngx_http_uwsgi_module.xml
+++ b/xml/en/docs/http/ngx_http_uwsgi_module.xml
@@ -17,6 +17,13 @@
 <para>
 The <literal>ngx_http_uwsgi_module</literal> module allows passing
 requests to a uwsgi server.
+
+Warning: This module assumes that the server it passes requests
+to is trusted.  It is not to be used with untrusted uwsgi servers.
+
+If possible, using an AF_UNIX socket to connect to the uwsgi server
+is recommended, as it is faster and subject to filesystem access
+controls.
 </para>
 
 </section>


### PR DESCRIPTION
### Proposed changes

Nginx has various security limitations:

- Modules that proxy to upstream servers (HTTP/1.x, FastCGI, uwsgi, SCGI) assume that the upstream server is trusted
- Modules that set headers, trailers, URLs, or request methods do not check that the result is valid.


### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
