### PR TITLE
Linux packages: Actualized the list of supported distributions.

### DIFF
--- a/xml/en/linux_packages.xml
+++ b/xml/en/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: Linux packages"
          link="/en/linux_packages.html"
          lang="en"
-         rev="116">
+         rev="117">
 
 <section name="Supported distributions and versions" id="distributions">
 
@@ -93,11 +93,6 @@ versions:
 </tr>
 
 <tr>
-<td width="30%">25.10 “questing”</td>
-<td>x86_64, aarch64/arm64</td>
-</tr>
-
-<tr>
 <td width="30%">26.04 “resolute”</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
@@ -153,6 +148,11 @@ versions:
 <td>x86_64, aarch64/arm64</td>
 </tr>
 
+<tr>
+<td width="30%">3.24</td>
+<td>x86_64, aarch64/arm64</td>
+</tr>
+
 </table>
 </para>
 
@@ -164,11 +164,6 @@ versions:
 <tr>
 <td width="30%">Version</td>
 <td>Supported platforms</td>
-</tr>
-
-<tr>
-<td width="30%">2 (LTS)</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>

--- a/xml/ru/linux_packages.xml
+++ b/xml/ru/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: пакеты для Linux"
          link="/ru/linux_packages.html"
          lang="ru"
-         rev="116">
+         rev="117">
 
 <section name="Поддерживаемые дистрибутивы и версии" id="distributions">
 
@@ -93,11 +93,6 @@
 </tr>
 
 <tr>
-<td width="30%">25.10 “questing”</td>
-<td>x86_64, aarch64/arm64</td>
-</tr>
-
-<tr>
 <td width="30%">26.04 “resolute”</td>
 <td>x86_64, aarch64/arm64</td>
 </tr>
@@ -153,6 +148,11 @@
 <td>x86_64, aarch64/arm64</td>
 </tr>
 
+<tr>
+<td width="30%">3.24</td>
+<td>x86_64, aarch64/arm64</td>
+</tr>
+
 </table>
 </para>
 
@@ -164,11 +164,6 @@
 <tr>
 <td width="30%">Версия</td>
 <td>Поддерживаемые платформы</td>
-</tr>
-
-<tr>
-<td width="30%">2 (LTS)</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
Namely, removed Amazon Linux 2 and Ubuntu 25.04 due to EOL and added Alpine Linux 3.24.