### PR TITLE
Documented the xml_external_entities directive

### DIFF
--- a/xml/en/docs/http/ngx_http_xslt_module.xml
+++ b/xml/en/docs/http/ngx_http_xslt_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_http_xslt_module"
         link="/en/docs/http/ngx_http_xslt_module.html"
         lang="en"
-        rev="3">
+        rev="4">
 
 <section id="summary">
 
@@ -68,6 +68,28 @@ It is enough to declare just the required character entities, for example:
 <example>
 &lt;!ENTITY nbsp "&amp;#xa0;"&gt;
 </example>
+</para>
+
+</directive>
+
+
+<directive name="xml_external_entities">
+<syntax><literal>on</literal> | <literal>off</literal></syntax>
+<default>off</default>
+<context>http</context>
+<context>server</context>
+<context>location</context>
+<appeared-in>1.31.3</appeared-in>
+
+<para>
+Enables or disables loading of external entities declared in the
+internal DTD subset of the processed XML.
+Only loading of file-based external entities is supported.
+<note>
+To prevent reading arbitrary local files accessible to the worker
+process, it is recommended to enable external entities only when the
+processed XML is trusted.
+</note>
 </para>
 
 </directive>

--- a/xml/ru/docs/http/ngx_http_xslt_module.xml
+++ b/xml/ru/docs/http/ngx_http_xslt_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_http_xslt_module"
         link="/ru/docs/http/ngx_http_xslt_module.html"
         lang="ru"
-        rev="3">
+        rev="4">
 
 <section id="summary">
 
@@ -68,6 +68,29 @@ location / {
 <example>
 &lt;!ENTITY nbsp "&amp;#xa0;"&gt;
 </example>
+</para>
+
+</directive>
+
+
+<directive name="xml_external_entities">
+<syntax><literal>on</literal> | <literal>off</literal></syntax>
+<default>off</default>
+<context>http</context>
+<context>server</context>
+<context>location</context>
+<appeared-in>1.31.3</appeared-in>
+
+<para>
+Разрешает или запрещает загрузку внешних сущностей, объявленных
+во внутреннем подмножестве DTD обрабатываемого XML.
+Поддерживается только загрузка внешних сущностей из файлов.
+<note>
+Чтобы предотвратить чтение произвольных локальных файлов,
+доступных рабочему процессу, рекомендуется разрешать загрузку
+внешних сущностей только в том случае, если обрабатываемый XML
+получен из доверенного источника.
+</note>
 </para>
 
 </directive>


### PR DESCRIPTION
Documents the `xml_external_entities` directive in the `ngx_http_xslt_module`
reference (English and Russian), corresponding to the source change in
nginx/nginx#1549.

The directive controls loading of external entities declared in the internal
DTD subset of the processed XML; loading is disabled by default and can be
re-enabled where the processed XML is trusted. Documenting the default-off
behaviour also clarifies the module's handling of document-declared external
entities.

Notes for review:
- `<appeared-in>` is set to the placeholder `X.Y.Z` in both files, pending the
  nginx release that carries the merged source change.
- Module `rev` bumped 3 -> 4 in both en/ru.
- The Russian translation follows the existing module wording; a native review
  is welcome.
