### PR TITLE
Image filter: documented the image_filter_max_pixels directive

### DIFF
--- a/xml/en/docs/http/ngx_http_image_filter_module.xml
+++ b/xml/en/docs/http/ngx_http_image_filter_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_http_image_filter_module"
         link="/en/docs/http/ngx_http_image_filter_module.html"
         lang="en"
-        rev="4">
+        rev="5">
 
 <section id="summary">
 
@@ -200,6 +200,28 @@ Acceptable values are in the range from 1 to 100.
 Lesser values usually imply both lower image quality and less data to transfer.
 The maximum recommended value is 95.
 Parameter value can contain variables.
+</para>
+
+</directive>
+
+
+<directive name="image_filter_max_pixels">
+<syntax><value>pixels</value></syntax>
+<default>20000000</default>
+<context>http</context>
+<context>server</context>
+<context>location</context>
+<appeared-in>1.31.4</appeared-in>
+
+<para>
+Limits the maximum size of an image being processed, in pixels
+(width multiplied by height).
+The limit applies both to the source image
+and to the transformation result.
+When the limit is exceeded, the image is not processed
+and the server returns error
+<http-status code="415" text="Unsupported Media Type"/>.
+The zero value disables the limit.
 </para>
 
 </directive>

--- a/xml/ru/docs/http/ngx_http_image_filter_module.xml
+++ b/xml/ru/docs/http/ngx_http_image_filter_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_http_image_filter_module"
         link="/ru/docs/http/ngx_http_image_filter_module.html"
         lang="ru"
-        rev="4">
+        rev="5">
 
 <section id="summary">
 
@@ -209,6 +209,28 @@ location = /empty {
 </directive>
 
 
+<directive name="image_filter_max_pixels">
+<syntax><value>пикселы</value></syntax>
+<default>20000000</default>
+<context>http</context>
+<context>server</context>
+<context>location</context>
+<appeared-in>1.31.4</appeared-in>
+
+<para>
+Ограничивает максимальный размер обрабатываемого изображения в пикселах
+(ширину, умноженную на высоту).
+Ограничение распространяется как на исходное изображение,
+так и на результат преобразования.
+При превышении ограничения изображение не обрабатывается
+и сервер вернёт ошибку
+<http-status code="415" text="Unsupported Media Type"/>.
+Значение <literal>0</literal> отключает ограничение.
+</para>
+
+</directive>
+
+
 <directive name="image_filter_sharpen">
 <syntax><value>процент</value></syntax>
 <default>0</default>
@@ -219,7 +241,7 @@ location = /empty {
 <para>
 Повышает резкость итогового изображения.
 Процент резкости может быть больше 100.
-Значение 0 отключает повышение резкости.
+Значение <literal>0</literal> отключает повышение резкости.
 В значении параметра допустимо использование переменных.
 </para>
 


### PR DESCRIPTION
Documents the new `image_filter_max_pixels` directive in the
`ngx_http_image_filter_module` reference, English and Russian.

The directive limits the size, in pixels, of an image being processed
(source or transformation result); when the limit is exceeded the server
returns `415 (Unsupported Media Type)`. The default is 20 million pixels;
`0` disables the limit.

Companion to the source change nginx/nginx#1575.

Note: the `<appeared-in>` version is a placeholder (1.31.4) and should be
set to the actual release the directive ships in.
