### PR TITLE
Updated availability note for SSL ECH

### DIFF
--- a/xml/en/docs/http/ngx_http_ssl_module.xml
+++ b/xml/en/docs/http/ngx_http_ssl_module.xml
@@ -10,7 +10,7 @@
 <module name="Module ngx_http_ssl_module"
         link="/en/docs/http/ngx_http_ssl_module.html"
         lang="en"
-        rev="75">
+        rev="76">
 
 <section id="summary">
 
@@ -588,9 +588,7 @@ in shared mode.
 
 <para>
 <note>
-The directive is currently supported only when using OpenSSL
-<link url="https://github.com/openssl/openssl/tree/feature/ech">ECH
-feature branch</link>.
+The directive is supported when using OpenSSL 4.0 or higher.
 </note>
 </para>
 
@@ -1377,10 +1375,8 @@ returns the result of TLS 1.3 <link id="ssl_ech_file">ECH</link> processing:
 “<literal>SUCCESS</literal>”, or
 “<literal>NOT_TRIED</literal>” (1.29.4);
 <note>
-The variable is currently supported only when using OpenSSL
-<link url="https://github.com/openssl/openssl/tree/feature/ech">ECH feature branch</link>
-and is therefore subject to change.
-The variable value will otherwise be an empty string.
+The variable is supported only when using OpenSSL version 4.0 or higher.
+With older versions, the variable value will be an empty string.
 </note>
 </tag-desc>
 

--- a/xml/en/docs/stream/ngx_stream_ssl_module.xml
+++ b/xml/en/docs/stream/ngx_stream_ssl_module.xml
@@ -9,7 +9,7 @@
 <module name="Module ngx_stream_ssl_module"
         link="/en/docs/stream/ngx_stream_ssl_module.html"
         lang="en"
-        rev="48">
+        rev="49">
 
 <section id="summary">
 
@@ -517,9 +517,7 @@ in shared mode.
 
 <para>
 <note>
-The directive is currently supported only when using OpenSSL
-<link url="https://github.com/openssl/openssl/tree/feature/ech">ECH
-feature branch</link>.
+The directive is supported when using OpenSSL 4.0 or higher.
 </note>
 </para>
 
@@ -1245,10 +1243,8 @@ returns the result of TLS 1.3 <link id="ssl_ech_file">ECH</link> processing:
 “<literal>SUCCESS</literal>”, or
 “<literal>NOT_TRIED</literal>” (1.29.4);
 <note>
-The variable is currently supported only when using OpenSSL
-<link url="https://github.com/openssl/openssl/tree/feature/ech">ECH feature branch</link>
-and is therefore subject to change.
-The variable value will otherwise be an empty string.
+The variable is supported only when using OpenSSL version 4.0 or higher.
+With older versions, the variable value will be an empty string.
 </note>
 </tag-desc>
 

--- a/xml/ru/docs/http/ngx_http_ssl_module.xml
+++ b/xml/ru/docs/http/ngx_http_ssl_module.xml
@@ -10,7 +10,7 @@
 <module name="Модуль ngx_http_ssl_module"
         link="/ru/docs/http/ngx_http_ssl_module.html"
         lang="ru"
-        rev="75">
+        rev="76">
 
 <section id="summary">
 
@@ -590,9 +590,7 @@ ssl_ecdh_curve prime256v1:secp384r1;
 
 <para>
 <note>
-В настоящее время директива поддерживается только при использовании
-<link url="https://github.com/openssl/openssl/tree/feature/ech">ветки
-разработки ECH</link> OpenSSL.
+Директива поддерживается при использовании OpenSSL 4.0 и выше.
 </note>
 </para>
 
@@ -1381,10 +1379,8 @@ prime256v1
 “<literal>SUCCESS</literal>” или
 “<literal>NOT_TRIED</literal>” (1.29.4);
 <note>
-В настоящее время переменная поддерживается при использовании
-<link url="https://github.com/openssl/openssl/tree/feature/ech">ветки разработки ECH</link>
-и, таким образом, может измениться.
-В остальных случаях значением переменной будет пустая строка.
+Переменная поддерживается при использовании OpenSSL версии 4.0 и выше.
+При использовании более старых версий значением переменной будет пустая строка.
 </note>
 </tag-desc>
 

--- a/xml/ru/docs/stream/ngx_stream_ssl_module.xml
+++ b/xml/ru/docs/stream/ngx_stream_ssl_module.xml
@@ -9,7 +9,7 @@
 <module name="Модуль ngx_stream_ssl_module"
         link="/ru/docs/stream/ngx_stream_ssl_module.html"
         lang="ru"
-        rev="48">
+        rev="49">
 
 <section id="summary">
 
@@ -519,9 +519,7 @@ ssl_ecdh_curve prime256v1:secp384r1;
 
 <para>
 <note>
-В настоящее время директива поддерживается только при использовании
-<link url="https://github.com/openssl/openssl/tree/feature/ech">ветки
-разработки ECH</link> OpenSSL.
+Директива поддерживается при использовании OpenSSL 4.0 и выше.
 </note>
 </para>
 
@@ -1248,10 +1246,8 @@ prime256v1
 “<literal>SUCCESS</literal>” или
 “<literal>NOT_TRIED</literal>” (1.29.4);
 <note>
-В настоящее время переменная поддерживается при использовании
-<link url="https://github.com/openssl/openssl/tree/feature/ech">ветки разработки ECH</link>
-и, таким образом, может измениться.
-В остальных случаях значением переменной будет пустая строка.
+Переменная поддерживается при использовании OpenSSL версии 4.0 и выше.
+При использовании более старых версий значением переменной будет пустая строка.
 </note>
 </tag-desc>
 


### PR DESCRIPTION
The ECH feature is released in OpenSSL 4.0.
