### PR TITLE
Documented the SSL context used on connections without SNI

### DIFF
--- a/xml/en/docs/http/configuring_https_servers.xml
+++ b/xml/en/docs/http/configuring_https_servers.xml
@@ -406,6 +406,47 @@ therefore SNI is not available
 
 </section>
 
+
+<section id="client_ssl_certificates" name="Client SSL certificates">
+
+<para>
+<link doc="ngx_http_ssl_module.xml" id="ssl_verify_client">Verification
+of client SSL certificates</link> should be configured with care
+in named-based HTTPS servers.
+If a client does not request a server name through SNI,
+the entire SSL configuration of the default server is used
+to establish the connection.
+In this case,
+the server configuration that processes the HTTP request
+may be switched afterwards; see
+<link doc="server_names.xml" id="virtual_server_selection">Virtual
+server selection</link>.
+As a result, a client with a certificate trusted by the default server
+may be able to request resources from other servers
+listening on the same address,
+including servers that verify client certificates
+against a different certificate authority.
+</para>
+
+<para>
+If this is not desired,
+connections without SNI should be limited by
+<link doc="ngx_http_ssl_module.xml" id="ssl_reject_handshake"/>
+in the default server.
+This will enforce the check for inappropriate
+<link url="https://datatracker.ietf.org/doc/html/rfc9113#name-connection-reuse">connection
+reuse</link>:
+<programlisting>
+server {
+    listen              443 ssl default_server;
+    ssl_reject_handshake on;
+    return 421;
+}
+</programlisting>
+</para>
+
+</section>
+
 </section>
 
 

--- a/xml/ru/docs/http/configuring_https_servers.xml
+++ b/xml/ru/docs/http/configuring_https_servers.xml
@@ -405,6 +405,47 @@ therefore SNI is not available
 
 </section>
 
+
+<section id="client_ssl_certificates" name="Клиентские SSL-сертификаты">
+
+<para>
+<link doc="ngx_http_ssl_module.xml" id="ssl_verify_client">Проверку
+клиентских SSL-сертификатов</link> в HTTPS-серверах, выбираемых по имени,
+следует настраивать с осторожностью.
+Если клиент не запросил имя сервера с помощью SNI,
+для установления соединения используется вся конфигурация SSL
+сервера по умолчанию.
+В этом случае
+конфигурация сервера, обрабатывающего HTTP-запрос,
+может впоследствии измениться; см.
+<link doc="server_names.xml" id="virtual_server_selection">выбор
+виртуального сервера</link>.
+В результате клиент с сертификатом, которому доверяет сервер по умолчанию,
+может запрашивать ресурсы у других серверов,
+слушающих на том же адресе,
+включая серверы, проверяющие клиентские сертификаты
+по сертификатам другого CA.
+</para>
+
+<para>
+Если это нежелательно,
+соединения без SNI следует ограничить директивой
+<link doc="ngx_http_ssl_module.xml" id="ssl_reject_handshake"/>
+на сервере по умолчанию.
+Это обеспечит проверку недопустимого
+<link url="https://datatracker.ietf.org/doc/html/rfc9113#name-connection-reuse">повторного
+использования соединения</link>:
+<programlisting>
+server {
+    listen              443 ssl default_server;
+    ssl_reject_handshake on;
+    return 421;
+}
+</programlisting>
+</para>
+
+</section>
+
 </section>
 
 


### PR DESCRIPTION
## Problem

On a connection without SNI, the entire SSL configuration of the default server
is used to establish the connection, client certificate verification included,
while the `server` block that processes the request is chosen afterwards from the
`Host` request header field. A client holding a certificate trusted by the
default server can therefore request resources from other servers listening on
the same address, including servers that verify client certificates against a
different certificate authority.

This is long-standing intended behaviour, and reports of it are configuration
issues rather than defects: the cross-server 421 restriction added in b720f650b
is about connection reuse across server names (RFC 6066), is deliberately gated
on SNI having been negotiated, and was never meant to isolate client-certificate
authorities between virtual servers.

It is, however, undocumented. The documentation currently explains only that a
non-SNI connection gets the default server's *certificate*, which does not lead
a reader to the client-certificate consequence. The same report has arrived
repeatedly over the years as a suspected vulnerability, and when this was last
discussed the conclusion was that the fix belongs in the documentation.

## Solution

- `configuring_https_servers.xml`, in "Name-based HTTPS servers": generalise the
  existing paragraph about the default server's certificate to the whole SSL
  configuration, spell out the client-certificate consequence, cross-reference
  the "Virtual server selection" section of the Server names document from the
  sentence noting that the request server is chosen by `Host`, and note the two
  remedies -- `ssl_reject_handshake` in the default server with no client
  certificate verification there, and checking `$ssl_client_s_dn` /
  `$ssl_client_i_dn` in the server that processes the request, so that
  authorization is not inferred from authentication alone.
- `ngx_http_ssl_module.xml`, on `ssl_verify_client`: a short note pointing at
  that section, so the caveat is reachable from the reference documentation and
  not only from the tutorial.
- Russian translation (`xml/ru/...`) added in parallel, using "CA" for the
  certificate-authority wording to match `ssl_client_certificate`.

No behaviour change; documentation only.

## Testing

- `xmllint --noout --valid` against `dtd/` passes for all four files
  (English and Russian).
- Both pages build with the project's makefile, and the rendered output was
  checked: the new links resolve and their target anchors are present in the
  built pages.
