### PR TITLE
Documented restricting $ssl_server_name in certificate file names

### DIFF
--- a/xml/en/docs/http/ngx_http_ssl_module.xml
+++ b/xml/en/docs/http/ngx_http_ssl_module.xml
@@ -187,6 +187,28 @@ a certificate will be loaded for each SSL handshake,
 and this may have a negative impact on performance.
 </para>
 
+<para>
+Since <link id="var_ssl_server_name">$ssl_server_name</link>
+is chosen by the client,
+loading certificates with such a file name should be filtered:
+<example>
+map $ssl_server_name $name {
+    hostnames;
+
+    default        www.example.org;
+
+    .example.org   www.example.org;
+    .example.com   www.example.com;
+}
+
+server {
+    listen              443 ssl;
+    ssl_certificate     certs/$name.crt;
+    ssl_certificate_key certs/$name.key;
+}
+</example>
+</para>
+
 <para id="ssl_certificate_data">
 The value
 <literal>data</literal>:<value>$variable</value>
@@ -225,7 +247,7 @@ IP addresses</link>.
 Defines a cache that stores
 <link id="ssl_certificate">SSL certificates</link> and
 <link id="ssl_certificate_key">secret keys</link>
-specified with <link id="ssl_certificate_key_variables">variables</link>.
+specified with <link id="ssl_certificate_variables">variables</link>.
 </para>
 
 <para>
@@ -273,8 +295,6 @@ disables the cache.
 <para>
 Example:
 <example>
-ssl_certificate       $ssl_server_name.crt;
-ssl_certificate_key   $ssl_server_name.key;
 ssl_certificate_cache max=1000 inactive=20s valid=1m;
 </example>
 </para>

--- a/xml/en/docs/stream/ngx_stream_ssl_module.xml
+++ b/xml/en/docs/stream/ngx_stream_ssl_module.xml
@@ -168,6 +168,28 @@ a certificate will be loaded for each SSL handshake,
 and this may have a negative impact on performance.
 </para>
 
+<para>
+Since <link id="var_ssl_server_name">$ssl_server_name</link>
+is chosen by the client,
+loading certificates with such a file name should be filtered:
+<example>
+map $ssl_server_name $name {
+    hostnames;
+
+    default        www.example.org;
+
+    .example.org   www.example.org;
+    .example.com   www.example.com;
+}
+
+server {
+    listen              443 ssl;
+    ssl_certificate     certs/$name.crt;
+    ssl_certificate_key certs/$name.key;
+}
+</example>
+</para>
+
 <para id="ssl_certificate_data">
 The value
 <literal>data</literal>:<value>$variable</value>
@@ -207,7 +229,7 @@ IP addresses</link>.
 Defines a cache that stores
 <link id="ssl_certificate">SSL certificates</link> and
 <link id="ssl_certificate_key">secret keys</link>
-specified with <link id="ssl_certificate_key_variables">variables</link>.
+specified with <link id="ssl_certificate_variables">variables</link>.
 </para>
 
 <para>
@@ -255,8 +277,6 @@ disables the cache.
 <para>
 Example:
 <example>
-ssl_certificate       $ssl_server_name.crt;
-ssl_certificate_key   $ssl_server_name.key;
 ssl_certificate_cache max=1000 inactive=20s valid=1m;
 </example>
 </para>

--- a/xml/ru/docs/http/ngx_http_ssl_module.xml
+++ b/xml/ru/docs/http/ngx_http_ssl_module.xml
@@ -189,6 +189,28 @@ ssl_certificate_key $ssl_server_name.key;
 что может отрицательно влиять на производительность.
 </para>
 
+<para>
+Поскольку значение <link id="var_ssl_server_name">$ssl_server_name</link>
+выбирается клиентом,
+загрузку сертификатов с таким именем файла следует фильтровать:
+<example>
+map $ssl_server_name $name {
+    hostnames;
+
+    default        www.example.org;
+
+    .example.org   www.example.org;
+    .example.com   www.example.com;
+}
+
+server {
+    listen              443 ssl;
+    ssl_certificate     certs/$name.crt;
+    ssl_certificate_key certs/$name.key;
+}
+</example>
+</para>
+
 <para id="ssl_certificate_data">
 Вместо <value>файла</value> можно указать значение
 <literal>data</literal>:<value>$переменная</value> (1.15.10),
@@ -227,7 +249,7 @@ IP-адресах</link>.
 Задаёт кэш, в котором могут храниться
 <link id="ssl_certificate">SSL-сертификаты</link> и
 <link id="ssl_certificate_key">секретные ключи</link>,
-полученные из <link id="ssl_certificate_key_variables">переменных</link>.
+полученные из <link id="ssl_certificate_variables">переменных</link>.
 </para>
 
 <para>
@@ -275,8 +297,6 @@ IP-адресах</link>.
 <para>
 Пример:
 <example>
-ssl_certificate       $ssl_server_name.crt;
-ssl_certificate_key   $ssl_server_name.key;
 ssl_certificate_cache max=1000 inactive=20s valid=1m;
 </example>
 </para>

--- a/xml/ru/docs/stream/ngx_stream_ssl_module.xml
+++ b/xml/ru/docs/stream/ngx_stream_ssl_module.xml
@@ -170,6 +170,28 @@ ssl_certificate_key $ssl_server_name.key;
 что может отрицательно влиять на производительность.
 </para>
 
+<para>
+Поскольку значение <link id="var_ssl_server_name">$ssl_server_name</link>
+выбирается клиентом,
+загрузку сертификатов с таким именем файла следует фильтровать:
+<example>
+map $ssl_server_name $name {
+    hostnames;
+
+    default        www.example.org;
+
+    .example.org   www.example.org;
+    .example.com   www.example.com;
+}
+
+server {
+    listen              443 ssl;
+    ssl_certificate     certs/$name.crt;
+    ssl_certificate_key certs/$name.key;
+}
+</example>
+</para>
+
 <para id="ssl_certificate_data">
 Вместо <value>файла</value> можно указать значение
 <literal>data</literal>:<value>$переменная</value> (1.15.10),
@@ -209,7 +231,7 @@ IP-адресах</link>.
 Задаёт кэш, в котором могут храниться
 <link id="ssl_certificate">SSL-сертификаты</link> и
 <link id="ssl_certificate_key">секретные ключи</link>,
-полученные из <link id="ssl_certificate_key_variables">переменных</link>.
+полученные из <link id="ssl_certificate_variables">переменных</link>.
 </para>
 
 <para>
@@ -257,8 +279,6 @@ IP-адресах</link>.
 <para>
 Пример:
 <example>
-ssl_certificate       $ssl_server_name.crt;
-ssl_certificate_key   $ssl_server_name.key;
 ssl_certificate_cache max=1000 inactive=20s valid=1m;
 </example>
 </para>


### PR DESCRIPTION
## Problem

The documentation for `ssl_certificate` presents `$ssl_server_name` used directly
in the certificate file name as a straightforward SNI-based selection pattern,
with only a performance caveat. `$ssl_server_name` holds the server name
requested by the client and is not validated, so using it directly in the file
name lets a client influence which file is loaded -- for example, by sending an
SNI value containing a path separator or `../`.

The behavior is by design (the variable intentionally reflects the raw SNI; see
fd97b2a80), so this is a documentation gap rather than a code defect, but the
example currently leads administrators toward an unsafe configuration.

## Solution

Added a note to the `ssl_certificate` variables section explaining that
`$ssl_server_name` is client-controlled and not validated, and recommending that
the value be restricted to an expected set of names, for example with a `map`
allowlist. English and Russian.

## Testing

`xmllint --noout --valid` against `dtd/` passes for both files.
