### PR TITLE
Document HTTP_* parameter suppression in *_param directives

### DIFF
--- a/xml/en/docs/http/ngx_http_fastcgi_module.xml
+++ b/xml/en/docs/http/ngx_http_fastcgi_module.xml
@@ -1338,6 +1338,17 @@ fastcgi_param HTTPS           $https if_not_empty;
 </example>
 </para>
 
+<para>
+If the <value>parameter</value> name begins with
+“<literal>HTTP_</literal>” and its <value>value</value> is set to an
+empty string, the parameter is not passed to the FastCGI server, and
+the corresponding client request header field is not passed either.
+This can be used to prevent forwarding of a request header field:
+<example>
+fastcgi_param HTTP_AUTHORIZATION "";
+</example>
+</para>
+
 </directive>
 
 

--- a/xml/en/docs/http/ngx_http_scgi_module.xml
+++ b/xml/en/docs/http/ngx_http_scgi_module.xml
@@ -1238,6 +1238,17 @@ scgi_param HTTPS $https if_not_empty;
 </example>
 </para>
 
+<para>
+If the <value>parameter</value> name begins with
+“<literal>HTTP_</literal>” and its <value>value</value> is set to an
+empty string, the parameter is not passed to the SCGI server, and
+the corresponding client request header field is not passed either.
+This can be used to prevent forwarding of a request header field:
+<example>
+scgi_param HTTP_AUTHORIZATION "";
+</example>
+</para>
+
 </directive>
 
 

--- a/xml/en/docs/http/ngx_http_uwsgi_module.xml
+++ b/xml/en/docs/http/ngx_http_uwsgi_module.xml
@@ -1269,6 +1269,17 @@ uwsgi_param HTTPS $https if_not_empty;
 </example>
 </para>
 
+<para>
+If the <value>parameter</value> name begins with
+“<literal>HTTP_</literal>” and its <value>value</value> is set to an
+empty string, the parameter is not passed to the uwsgi server, and
+the corresponding client request header field is not passed either.
+This can be used to prevent forwarding of a request header field:
+<example>
+uwsgi_param HTTP_AUTHORIZATION "";
+</example>
+</para>
+
 </directive>
 
 


### PR DESCRIPTION
Adds a paragraph to the `fastcgi_param`, `uwsgi_param`, and `scgi_param` directive documentation describing the empty-value HTTP_* suppression idiom.

For all three modules, if a `*_param` directive names a parameter beginning with `HTTP_` and gives it a literal empty string as its value, the parameter is not passed to the upstream server and the corresponding client request header field is also suppressed from auto-forwarding. This is a deliberate idiom (used e.g. to strip `HTTP_AUTHORIZATION` before forwarding) but was not documented, leading to confusion — see nginx/nginx#484.

Behaviour verified in `ngx_http_uwsgi_module.c` L2192–2210, `ngx_http_fastcgi_module.c` L3478–3494, and `ngx_http_scgi_module.c` L1869–1885.