### PR TITLE
NJS integration points

### DIFF
--- a/xml/en/GNUmakefile
+++ b/xml/en/GNUmakefile
@@ -147,6 +147,7 @@ REFS =									\
 		njs/compatibility					\
 		njs/engine						\
 		njs/install						\
+		njs/integration						\
 		njs/native_modules					\
 		njs/preload_objects					\
 		njs/reference						\

--- a/xml/en/docs/http/ngx_http_js_module.xml
+++ b/xml/en/docs/http/ngx_http_js_module.xml
@@ -9,15 +9,14 @@
 <module name="Module ngx_http_js_module"
         link="/en/docs/http/ngx_http_js_module.html"
         lang="en"
-        rev="62">
+        rev="63">
 
 <section id="summary">
 
 <para>
 The <literal>ngx_http_js_module</literal> module is used to implement
-location and variable handlers
-in <link doc="../njs/index.xml">njs</link> —
-a subset of the JavaScript language.
+location, variable, and filter handlers in JavaScript
+with <link doc="../njs/index.xml">njs</link>.
 </para>
 
 <para>
@@ -735,7 +734,8 @@ since <link doc="../njs/changes.xml" id="njs0.7.7">0.7.7</link>.
 <appeared-in>0.4.0</appeared-in>
 
 <para>
-Imports a module that implements location and variable handlers in njs.
+Imports a module that implements location, variable,
+and filter handlers in njs.
 The <literal>export_name</literal> is used as a namespace
 to access module functions.
 If the <literal>export_name</literal> is not specified,
@@ -929,7 +929,8 @@ by default, there is no delay.
 </para>
 
 <para>
-By default, the <literal>js_handler</literal> is executed on worker process 0.
+By default, the <literal>js_periodic</literal> handler
+is executed on worker process 0.
 The optional <literal>worker_affinity</literal> parameter
 allows specifying particular worker processes
 where the location content handler should be executed.

--- a/xml/en/docs/http/ngx_http_js_module.xml
+++ b/xml/en/docs/http/ngx_http_js_module.xml
@@ -9,7 +9,7 @@
 <module name="Module ngx_http_js_module"
         link="/en/docs/http/ngx_http_js_module.html"
         lang="en"
-        rev="63">
+        rev="64">
 
 <section id="summary">
 
@@ -134,10 +134,10 @@ async function fetch(r) {
     r.return(200, JSON.stringify(results, undefined, 4));
 }
 
-// since 0.7.0
+// since 0.9.5
 async function hash(r) {
     let hash = await crypto.subtle.digest('SHA-512', r.headersIn.host);
-    r.setReturnValue(Buffer.from(hash).toString('hex'));
+    return Buffer.from(hash).toString('hex');
 }
 
 export default {foo, summary, baz, hello, fetch, hash};

--- a/xml/en/docs/njs/engine.xml
+++ b/xml/en/docs/njs/engine.xml
@@ -42,7 +42,7 @@ new code should use the
 <para>
 njs is an embeddable JavaScript engine
 developed as a part of the njs module.
-See the <link doc="compatibility.xml">Сompatibility</link> section for details.
+See the <link doc="compatibility.xml">Compatibility</link> section for details.
 </para>
 
 </section>

--- a/xml/en/docs/njs/index.xml
+++ b/xml/en/docs/njs/index.xml
@@ -9,7 +9,7 @@
 <article name="nginx JavaScript module"
         link="/en/docs/njs/index.html"
         lang="en"
-        rev="40"
+        rev="41"
         toc="no">
 
 <section id="summary">
@@ -45,7 +45,7 @@ new configurations should use the
 </section>
 
 
-<section id="links">
+<section id="getting_started" name="Getting started">
 
 <para>
 <list type="bullet">
@@ -59,50 +59,27 @@ new configurations should use the
 </listitem>
 
 <listitem>
-<link doc="changes.xml"/>
-</listitem>
-
-<listitem>
-<link doc="reference.xml"/>
-</listitem>
-
-<listitem>
-<link doc="engine.xml"/>
-</listitem>
-
-<listitem>
-<link doc="native_modules.xml"/>
-</listitem>
-
-<listitem>
 <link url="https://github.com/nginx/njs-examples/">Examples</link>
-</listitem>
-
-<listitem>
-<link doc="security.xml"/>
-</listitem>
-
-<listitem>
-<link doc="compatibility.xml"/>
 </listitem>
 
 <listitem>
 <link doc="cli.xml"/>
 </listitem>
 
-<listitem>
-<link doc="preload_objects.xml"/>
-</listitem>
-
-<listitem>
-<link id="tested_os_and_platforms">Tested OS and platforms</link>
-</listitem>
-
 </list>
 </para>
 
+</section>
+
+
+<section id="links" name="Reference">
+
 <para>
 <list type="bullet">
+
+<listitem>
+<link doc="reference.xml"/>
+</listitem>
 
 <listitem>
 <link doc="../http/ngx_http_js_module.xml">
@@ -114,18 +91,51 @@ ngx_http_js_module</link>
 ngx_stream_js_module</link>
 </listitem>
 
-</list>
-</para>
+<listitem>
+<link doc="engine.xml"/>
+</listitem>
 
-<para>
-<list type="bullet">
+<listitem>
+<link doc="compatibility.xml"/>
+</listitem>
+
+<listitem>
+<link doc="native_modules.xml"/>
+</listitem>
+
+<listitem>
+<link doc="node_modules.xml"/>
+</listitem>
 
 <listitem>
 <link doc="typescript.xml"/>
 </listitem>
 
 <listitem>
-<link doc="node_modules.xml"/>
+<link doc="preload_objects.xml"/>
+</listitem>
+
+</list>
+</para>
+
+</section>
+
+
+<section id="project" name="Project">
+
+<para>
+<list type="bullet">
+
+<listitem>
+<link doc="changes.xml"/>
+</listitem>
+
+<listitem>
+<link doc="security.xml"/>
+</listitem>
+
+<listitem>
+<link id="tested_os_and_platforms">Tested OS and platforms</link>
 </listitem>
 
 </list>

--- a/xml/en/docs/njs/index.xml
+++ b/xml/en/docs/njs/index.xml
@@ -9,7 +9,7 @@
 <article name="nginx JavaScript module"
         link="/en/docs/njs/index.html"
         lang="en"
-        rev="39"
+        rev="40"
         toc="no">
 
 <section id="summary">
@@ -18,6 +18,17 @@
 njs is an nginx module that extends the server's functionality through
 JavaScript scripting, enabling the creation of custom
 server-side logic and <link id="usecases">more</link>.
+</para>
+
+<para>
+nginx calls JavaScript handlers at a fixed set of
+<link doc="integration.xml">integration points</link>:
+HTTP request and response processing phases, stream session phases,
+variable evaluation, and periodic timers.
+njs is not a standalone application runtime:
+it has no start-up script and no event loop of its own,
+JavaScript code runs only when nginx invokes a configured handler,
+and control returns to nginx once the handler completes.
 </para>
 
 <para>
@@ -41,6 +52,10 @@ new configurations should use the
 
 <listitem>
 <link doc="install.xml"/>
+</listitem>
+
+<listitem>
+<link doc="integration.xml"/>
 </listitem>
 
 <listitem>

--- a/xml/en/docs/njs/index.xml
+++ b/xml/en/docs/njs/index.xml
@@ -9,7 +9,7 @@
 <article name="nginx JavaScript module"
         link="/en/docs/njs/index.html"
         lang="en"
-        rev="38"
+        rev="39"
         toc="no">
 
 <section id="summary">
@@ -153,7 +153,7 @@ To use njs in nginx:
 
 <listitem>
 <para>
-<link doc="install.xml">install</link> njs scripting language
+<link doc="install.xml">install</link> njs
 </para>
 </listitem>
 

--- a/xml/en/docs/njs/integration.xml
+++ b/xml/en/docs/njs/integration.xml
@@ -1,0 +1,401 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (C) Nginx, Inc.
+  -->
+
+<!DOCTYPE article SYSTEM "../../../../dtd/article.dtd">
+
+<article name="Execution model and integration points"
+        link="/en/docs/njs/integration.html"
+        lang="en"
+        rev="1">
+
+<section id="summary">
+
+<para>
+JavaScript code in <link doc="index.xml">njs</link> never runs on its own.
+nginx calls it at a fixed set of integration points,
+each bound to a handler by a configuration directive.
+There is no start-up script, no background thread,
+and no event loop of its own:
+nginx invokes a handler, the handler runs, and control returns to nginx.
+</para>
+
+<para>
+This article describes when handlers are called
+and how to choose the right one.
+The exact contract of each directive is documented in
+<link doc="../http/ngx_http_js_module.xml">ngx_http_js_module</link>
+and
+<link doc="../stream/ngx_stream_js_module.xml">ngx_stream_js_module</link>.
+</para>
+
+</section>
+
+
+<section id="model" name="Execution model">
+
+<para>
+<list type="enum">
+
+<listitem>
+When the configuration is loaded, the
+<link doc="../http/ngx_http_js_module.xml" id="js_import">js_import</link>
+directive compiles the JavaScript modules.
+Syntax errors are reported at this point,
+before nginx starts serving traffic.
+</listitem>
+
+<listitem>
+When a request or a stream session reaches one of the integration
+points, a JavaScript context is created,
+the imported modules are evaluated in it,
+and the configured handlers are called.
+</listitem>
+
+<listitem>
+When the request or session is finished, the context is destroyed or,
+with the <link doc="engine.xml" id="quickjs_engine">QuickJS</link> engine,
+returned to a pool of reusable contexts.
+Nothing survives it except the data explicitly stored
+in a <link doc="reference.xml" id="ngx_shared">shared dictionary</link>
+or sent elsewhere.
+</listitem>
+
+</list>
+</para>
+
+<para>
+The only integration point not driven by a client request is
+<literal>js_periodic</literal>, which is driven by an nginx timer.
+JavaScript code cannot create an integration point of its own:
+it cannot open a listening socket, spawn a thread,
+or arrange to be called back outside of the handlers
+enabled by the configuration.
+</para>
+
+</section>
+
+
+<section id="http" name="HTTP integration points">
+
+<para>
+Handlers receive the
+<link doc="reference.xml" id="http">HTTP Request</link> object
+as the first argument, except for
+<literal>js_periodic</literal>, which receives a
+<link doc="reference.xml" id="periodic_session">Periodic Session</link>
+object.
+
+<table width="100%">
+
+<tr>
+<td width="27%"><b>Directive</b></td>
+<td width="38%"><b>When it runs</b></td>
+<td width="35%"><b>Asynchronous operations</b></td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_access">
+<literal>js_access</literal></link></td>
+<td>access phase, before the request is passed further</td>
+<td>supported</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_content">
+<literal>js_content</literal></link></td>
+<td>content phase, instead of an upstream or a static file</td>
+<td>supported</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_header_filter">
+<literal>js_header_filter</literal></link></td>
+<td>once, when the response header is ready to be sent</td>
+<td>not supported</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_body_filter">
+<literal>js_body_filter</literal></link></td>
+<td>for every chunk of the response body</td>
+<td>not supported</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_set">
+<literal>js_set</literal></link></td>
+<td>when the variable is referenced for the first time,
+at whatever phase that happens,
+or on every reference with <literal>nocache</literal></td>
+<td>not supported</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_periodic">
+<literal>js_periodic</literal></link></td>
+<td>at a regular interval, without a client request</td>
+<td>supported</td>
+</tr>
+
+</table>
+</para>
+
+<para>
+Handlers marked as not supporting asynchronous operations
+must produce their result before returning:
+they cannot wait for a subrequest, a fetch, or a timer.
+Such a handler may still be declared <literal>async</literal>
+as long as everything it awaits settles immediately.
+</para>
+
+<para>
+There is no handler for the rewrite or log phases.
+A <literal>js_set</literal> variable referenced from a directive
+of the corresponding phase is evaluated at that phase,
+which is the usual way to run code at the end of a request.
+</para>
+
+</section>
+
+
+<section id="stream" name="Stream integration points">
+
+<para>
+Handlers receive the
+<link doc="reference.xml" id="stream">Stream Session</link> object
+as the first argument, except for
+<literal>js_periodic</literal>, which receives a
+<link doc="reference.xml" id="periodic_session">Periodic Session</link>
+object.
+
+<table width="100%">
+
+<tr>
+<td width="27%"><b>Directive</b></td>
+<td width="38%"><b>When it runs</b></td>
+<td width="35%"><b>Asynchronous operations</b></td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_access">
+<literal>js_access</literal></link></td>
+<td>access phase</td>
+<td>in
+<link doc="reference.xml" id="s_on"><literal>s.on()</literal></link>
+callbacks</td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_preread">
+<literal>js_preread</literal></link></td>
+<td>preread phase, before the connection to the upstream is made</td>
+<td>in
+<link doc="reference.xml" id="s_on"><literal>s.on()</literal></link>
+callbacks</td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_filter">
+<literal>js_filter</literal></link></td>
+<td>content phase, to register data filters for both directions</td>
+<td>not supported</td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_set">
+<literal>js_set</literal></link></td>
+<td>when the variable is referenced for the first time,
+at whatever phase that happens,
+or on every reference with <literal>nocache</literal></td>
+<td>not supported</td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_periodic">
+<literal>js_periodic</literal></link></td>
+<td>at a regular interval, without a client session</td>
+<td>supported</td>
+</tr>
+
+</table>
+</para>
+
+<para>
+The <literal>js_access</literal>, <literal>js_preread</literal>,
+and <literal>js_filter</literal> handlers are called once,
+and are expected to register
+<link doc="reference.xml" id="s_on"><literal>s.on()</literal></link>
+callbacks for the data that arrives later.
+The handler itself must return immediately.
+</para>
+
+</section>
+
+
+<section id="choosing" name="Choosing an integration point">
+
+<para>
+<list type="tag">
+
+<tag-name>generate a response instead of proxying it</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_content">
+<literal>js_content</literal></link>
+</tag-desc>
+
+<tag-name>allow or deny a request or a connection,
+possibly after asking an external service</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_access">
+<literal>js_access</literal></link>
+for requests,
+<link doc="../stream/ngx_stream_js_module.xml" id="js_access">
+<literal>js_access</literal></link>
+for connections, or
+<link doc="../stream/ngx_stream_js_module.xml" id="js_preread">
+<literal>js_preread</literal></link>
+when the decision depends on the data sent by the client
+</tag-desc>
+
+<tag-name>compute a value for another nginx directive</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_set">
+<literal>js_set</literal></link>
+binds a handler to a variable,
+which is how a computed value reaches
+<literal>proxy_pass</literal>, <literal>log_format</literal>,
+and other directives that accept variables.
+A handler called earlier can also assign a variable declared with
+<link doc="../http/ngx_http_js_module.xml" id="js_var">
+<literal>js_var</literal></link>
+through
+<link doc="reference.xml" id="r_variables"><literal>r.variables</literal></link>
+</tag-desc>
+
+<tag-name>change the response of an upstream server</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_header_filter">
+<literal>js_header_filter</literal></link>
+for the header,
+<link doc="../http/ngx_http_js_module.xml" id="js_body_filter">
+<literal>js_body_filter</literal></link>
+for the body
+</tag-desc>
+
+<tag-name>rewrite the byte stream of a proxied connection</tag-name>
+<tag-desc>
+<link doc="../stream/ngx_stream_js_module.xml" id="js_filter">
+<literal>js_filter</literal></link>
+</tag-desc>
+
+<tag-name>refresh a cache, poll an API, or report metrics
+without a client request</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_periodic">
+<literal>js_periodic</literal></link>
+</tag-desc>
+
+</list>
+</para>
+
+<para>
+Several handlers may be combined for the same request,
+for example an access check followed by a body filter.
+Each of them is a separate call with its own constraints.
+</para>
+
+</section>
+
+
+<section id="state" name="State and lifetime">
+
+<para>
+Module top-level code is evaluated for each new JavaScript context,
+that is, for each request or stream session that invokes JavaScript.
+With the
+<link doc="engine.xml" id="quickjs_engine">QuickJS</link> engine,
+a context may instead be taken from a pool of reusable contexts,
+see
+<link doc="../http/ngx_http_js_module.xml" id="js_context_reuse">
+js_context_reuse</link>,
+in which case the modules are not evaluated again
+and the changes previously made to the module scope are inherited.
+</para>
+
+<para>
+<note>
+Module-level variables therefore cannot be used to pass data
+between requests or to cache results:
+depending on the engine and on context reuse,
+such data is either lost or inherited from an unrelated request.
+Expensive initialization in the module scope
+is also paid for on every new context.
+</note>
+</para>
+
+<para>
+nginx runs several worker processes
+that do not share memory by default.
+The njs mechanism for sharing state across workers is a
+<link doc="reference.xml" id="ngx_shared">shared dictionary</link>
+specified with the
+<link doc="../http/ngx_http_js_module.xml" id="js_shared_dict_zone">
+js_shared_dict_zone</link>
+directive.
+</para>
+
+<para>
+Asynchronous operations such as
+<link doc="reference.xml" id="ngx_fetch"><literal>ngx.fetch()</literal></link>,
+<link doc="reference.xml" id="r_subrequest">
+<literal>r.subrequest()</literal></link>,
+and
+<link doc="reference.xml" id="settimeout"><literal>setTimeout()</literal></link>
+are driven by the nginx event loop.
+There are no threads: a handler that computes for a long time
+blocks the whole worker process, and with it every other connection
+this worker serves.
+</para>
+
+</section>
+
+
+<section id="outside" name="Using njs outside of nginx">
+
+<para>
+<list type="bullet">
+
+<listitem>
+The <link doc="cli.xml">command-line utility</link>
+runs njs without nginx, which is convenient
+for developing and debugging the parts of a script
+that do not depend on the request.
+</listitem>
+
+<listitem>
+njs is not Node.js.
+It implements the ECMAScript language,
+a set of <link doc="reference.xml">built-in modules</link>,
+and the nginx objects,
+but not the Node.js API and not package resolution.
+Libraries can still be used if they are bundled beforehand, see
+<link doc="node_modules.xml"/>.
+</listitem>
+
+<listitem>
+<link doc="native_modules.xml">Native modules</link>
+extend njs with code written in C.
+The shared library is loaded when the configuration is parsed,
+and the module it registers is then imported
+like any other module.
+</listitem>
+
+</list>
+</para>
+
+</section>
+
+</article>

--- a/xml/en/docs/njs/reference.xml
+++ b/xml/en/docs/njs/reference.xml
@@ -9,7 +9,7 @@
 <article name="Reference"
         link="/en/docs/njs/reference.html"
         lang="en"
-        rev="138">
+        rev="139">
 
 <section id="summary">
 
@@ -713,15 +713,18 @@ sends the HTTP headers to the client
 sets the return value of the
 <link doc="../http/ngx_http_js_module.xml" id="js_set"/> handler
 (<link doc="changes.xml" id="njs0.7.0">0.7.0</link>).
-Unlike an ordinary return statement,
-this method should be used when the handler is JS async function.
-For example:
+<para>
+The method was made obsolete in
+<link doc="changes.xml" id="njs0.9.5">0.9.5</link>.
+Since this version, an <literal>async</literal> handler
+can return its value with an ordinary return statement:
 <example>
 async function js_set(r) {
     const digest = await crypto.subtle.digest('SHA-256', r.headersIn.host);
-    r.setReturnValue(digest);
+    return Buffer.from(digest).toString('hex');
 }
 </example>
+</para>
 </tag-desc>
 
 <tag-name id="r_status"><literal>r.status</literal></tag-name>
@@ -1182,15 +1185,18 @@ read only
 sets the return value of the
 <link doc="../stream/ngx_stream_js_module.xml" id="js_set"/> handler
 (<link doc="changes.xml" id="njs0.7.0">0.7.0</link>).
-Unlike an ordinary return statement,
-this method should be used when the handler is JS async function.
-For example:
+<para>
+The method was made obsolete in
+<link doc="changes.xml" id="njs0.9.5">0.9.5</link>.
+Since this version, an <literal>async</literal> handler
+can return its value with an ordinary return statement:
 <example>
-async function js_set(r) {
-    const digest = await crypto.subtle.digest('SHA-256', r.headersIn.host);
-    r.setReturnValue(digest);
+async function js_set(s) {
+    const digest = await crypto.subtle.digest('SHA-256', s.remoteAddress);
+    return Buffer.from(digest).toString('hex');
 }
 </example>
+</para>
 </tag-desc>
 
 <tag-name id="s_variables"><literal>s.variables{}</literal></tag-name>

--- a/xml/en/docs/stream/ngx_stream_js_module.xml
+++ b/xml/en/docs/stream/ngx_stream_js_module.xml
@@ -9,14 +9,14 @@
 <module name="Module ngx_stream_js_module"
         link="/en/docs/stream/ngx_stream_js_module.html"
         lang="en"
-        rev="56">
+        rev="57">
 
 <section id="summary">
 
 <para>
 The <literal>ngx_stream_js_module</literal> module is used to implement
-handlers in <link doc="../njs/index.xml">njs</link> —
-a subset of the JavaScript language.
+session and variable handlers in JavaScript
+with <link doc="../njs/index.xml">njs</link>.
 </para>
 
 <para>
@@ -556,7 +556,7 @@ are not supported.
 <appeared-in>0.4.0</appeared-in>
 
 <para>
-Imports a module that implements location and variable handlers in njs.
+Imports a module that implements session and variable handlers in njs.
 The <literal>export_name</literal> is used as a namespace
 to access module functions.
 If the <literal>export_name</literal> is not specified,
@@ -731,7 +731,8 @@ by default, there is no delay.
 </para>
 
 <para>
-By default, the <literal>js_handler</literal> is executed on worker process 0.
+By default, the <literal>js_periodic</literal> handler
+is executed on worker process 0.
 The optional <literal>worker_affinity</literal> parameter
 allows specifying particular worker processes
 where the location content handler should be executed.
@@ -907,7 +908,7 @@ Since <link doc="../njs/changes.xml" id="njs0.8.6">0.8.6</link>, when
 optional argument <literal>nocache</literal> is provided the handler
 is called every time it is referenced.
 Due to current limitations
-of the <link doc="ngx_stream_rewrite_module.xml">rewrite</link> module,
+of the <link doc="ngx_stream_set_module.xml">ngx_stream_set_module</link> module,
 when a <literal>nocache</literal> variable is referenced by the
 <link doc="ngx_stream_set_module.xml" id="set">set</link> directive
 its handler should always return a fixed-length value.

--- a/xml/ru/GNUmakefile
+++ b/xml/ru/GNUmakefile
@@ -123,6 +123,7 @@ REFS =									\
 		njs/compatibility					\
 		njs/engine						\
 		njs/install						\
+		njs/integration						\
 		njs/native_modules					\
 		njs/node_modules					\
 		njs/preload_objects					\

--- a/xml/ru/docs/http/ngx_http_js_module.xml
+++ b/xml/ru/docs/http/ngx_http_js_module.xml
@@ -9,15 +9,14 @@
 <module name="Модуль ngx_http_js_module"
         link="/ru/docs/http/ngx_http_js_module.html"
         lang="ru"
-        rev="59">
+        rev="63">
 
 <section id="summary">
 
 <para>
 Модуль <literal>ngx_http_js_module</literal> позволяет задавать
-обработчики location и переменных
-на <link doc="../njs/index.xml">njs</link> —
-подмножестве языка JavaScript.
+обработчики location, переменных и фильтров на JavaScript
+с помощью <link doc="../njs/index.xml">njs</link>.
 </para>
 
 <para>
@@ -208,10 +207,6 @@ function filter(r, data, flags) {
     r.sendBuffer(data.toLowerCase(), flags);
 }
 </example>
-Для отмены фильтра (блоки данных будут передаваться клиенту
-без вызова <literal>js_body_filter</literal>),
-можно использовать
-<link doc="../njs/reference.xml" id="r_done"><literal>r.done()</literal></link>.
 </para>
 
 <para>
@@ -219,7 +214,36 @@ function filter(r, data, flags) {
 необходимо очистить заголовок ответа <header>Content-Length</header>
 (если присутствует) в
 <link id="js_header_filter"><literal>js_header_filter</literal></link>,
-чтобы применить поблочное кодирование.
+чтобы применить поблочное кодирование:
+<example>
+example.conf:
+ location /foo {
+     # proxy_pass http://localhost:8080;
+
+    js_header_filter main.clear_content_length;
+    js_body_filter   main.filter;
+ }
+
+example.js:
+ function clear_content_length(r) {
+     delete r.headersOut['Content-Length'];
+ }
+</example>
+</para>
+
+<para>
+Для отмены фильтра (блоки данных будут передаваться клиенту
+без вызова <literal>js_body_filter</literal>),
+можно использовать
+<link doc="../njs/reference.xml" id="r_done"><literal>r.done()</literal></link>.
+Например, чтобы добавить данные в начало тела ответа:
+<example>
+function prepend(r, data, flags) {
+    r.sendBuffer("XXX");
+    r.sendBuffer(data, flags);
+    r.done();
+}
+</example>
 </para>
 
 <para>
@@ -340,7 +364,7 @@ example.js:
 <appeared-in>0.8.6</appeared-in>
 
 <para>
-Задаёт максимальное число контекстов JS для повторного использования
+Задаёт максимальное число контекстов JS для повторного использования в
 <link doc="../njs/engine.xml">движке QuickJS</link>.
 Каждый контекст используется для одного запроса.
 Завершённый контекст помещается в пул повторно используемых контекстов.
@@ -713,8 +737,8 @@ location /fetch {
 <appeared-in>0.4.0</appeared-in>
 
 <para>
-Импортирует модуль, позволяющий задавать обработчики location и переменных
-на njs.
+Импортирует модуль, позволяющий задавать обработчики location, переменных
+и фильтров на njs.
 <literal>Имя_экспорта</literal> является пространством имён
 при доступе к функциям модуля.
 Если <literal>имя_экспорта</literal> не задано,
@@ -730,6 +754,29 @@ js_import http.js;
 
 <para>
 Директив <literal>js_import</literal> может быть несколько.
+</para>
+
+<para>
+Если директива <literal>js_import</literal> указана внутри
+<link doc="ngx_http_core_module.xml" id="location"/>,
+импортированные модули видны только в том случае,
+если ранее при обработке запроса не выполнялся JavaScript-код.
+Для каждого запроса создаётся виртуальная машина (VM):
+или в момент первого обращения к переменной <link id="js_set"/>
+или первого вызова обработчика
+<link id="js_content"/>, <link id="js_header_filter"/>,
+<link id="js_body_filter"/> или <link id="js_access"/>.
+VM клонируется из конфигурации, активной в этот момент,
+и повторно используется во всех последующих вызовах JavaScript в рамках запроса.
+Таким образом, если обращение к любому из перечисленного происходит
+до того, как запрос будет сопоставлен с итоговым location,
+например в директиве
+<link doc="ngx_http_rewrite_module.xml" id="set"/> на уровне server,
+VM будет связана с набором импортов внешней области,
+и модули, импортированные в совпадающий <literal>location</literal>,
+будут недоступны.
+Чтобы избежать этого, такие импорты следует объявлять
+в общей родительской области конфигурации.
 </para>
 
 <para>
@@ -888,7 +935,8 @@ let result = mylib.add(5, 10);
 </para>
 
 <para>
-По умолчанию <literal>js_handler</literal> выполняется для рабочего процесса 0.
+По умолчанию обработчик <literal>js_periodic</literal>
+выполняется для рабочего процесса 0.
 Необязательный параметр <literal>worker_affinity</literal>
 позволяет указать рабочий процесс,
 для которого будет выполняться обработчик содержимого location.
@@ -1033,7 +1081,8 @@ js_preload_object map.json;
     <literal>zone</literal>=<value>имя</value>:<value>размер</value>
     [<literal>timeout</literal>=<value>время</value>]
     [<literal>type</literal>=<literal>строка</literal>|<literal>число</literal>]
-    [<literal>evict</literal>]</syntax>
+    [<literal>evict</literal>]
+    [<literal>state</literal>=<value>файл</value>]</syntax>
 <default/>
 <context>http</context>
 <appeared-in>0.8.0</appeared-in>
@@ -1069,6 +1118,13 @@ js_preload_object map.json;
 </para>
 
 <para>
+Необязательный параметр <literal>state</literal> задаёт <value>файл</value>,
+в котором хранится состояние разделяемого словаря
+в формате JSON, что позволяет сохранять его между перезапусками nginx
+(<link doc="../njs/changes.xml" id="njs0.9.1">0.9.1</link>).
+</para>
+
+<para>
 Пример:
 <example>
 example.conf:
@@ -1082,6 +1138,10 @@ example.conf:
 
     # Создаётся постоянный словарь размером 32Кб с числовыми значениями:
     js_shared_dict_zone zone=num:32k type=number;
+
+    # Создаётся словарь размером 1Мб со строковыми значениями
+    # и постоянным состоянием:
+    js_shared_dict_zone zone=persistent:1M state=/tmp/dict.json;
 
 example.js:
     function get(r) {

--- a/xml/ru/docs/http/ngx_http_js_module.xml
+++ b/xml/ru/docs/http/ngx_http_js_module.xml
@@ -9,7 +9,7 @@
 <module name="Модуль ngx_http_js_module"
         link="/ru/docs/http/ngx_http_js_module.html"
         lang="ru"
-        rev="63">
+        rev="64">
 
 <section id="summary">
 
@@ -134,10 +134,10 @@ async function fetch(r) {
     r.return(200, JSON.stringify(results, undefined, 4));
 }
 
-// начиная с версии 0.7.0
+// начиная с версии 0.9.5
 async function hash(r) {
     let hash = await crypto.subtle.digest('SHA-512', r.headersIn.host);
-    r.setReturnValue(Buffer.from(hash).toString('hex'));
+    return Buffer.from(hash).toString('hex');
 }
 
 export default {foo, summary, baz, hello, fetch, hash};

--- a/xml/ru/docs/njs/index.xml
+++ b/xml/ru/docs/njs/index.xml
@@ -9,7 +9,7 @@
 <article name="Модуль nginx JavaScript"
         link="/ru/docs/njs/index.html"
         lang="ru"
-        rev="38"
+        rev="39"
         toc="no">
 
 <section id="summary">
@@ -160,7 +160,7 @@ ngx_stream_js_module</link>
 <listitem id="hello_world">
 <para>
 создать файл сценария njs, например <path>http.js</path>.
-Описание свойств и методов языка njs
+Описание свойств и методов njs
 см. в <link doc="reference.xml">справочнике</link>.
 <example>
 function hello(r) {

--- a/xml/ru/docs/njs/index.xml
+++ b/xml/ru/docs/njs/index.xml
@@ -9,7 +9,7 @@
 <article name="Модуль nginx JavaScript"
         link="/ru/docs/njs/index.html"
         lang="ru"
-        rev="39"
+        rev="40"
         toc="no">
 
 <section id="summary">
@@ -18,6 +18,17 @@
 njs - это модуль nginx, который расширяет возможности сервера nginx с помощью
 сценариев JavaScript, позволяя создавать пользовательскую
 логику на стороне сервера и выполнять <link id="usecases">другие задачи</link>.
+</para>
+
+<para>
+nginx вызывает JavaScript-обработчики в фиксированном наборе
+<link doc="integration.xml">точек интеграции</link>:
+в фазах обработки HTTP-запроса и ответа, фазах stream-сессии,
+при вычислении переменных и по таймеру.
+njs не является самостоятельной средой выполнения приложений:
+стартовый сценарий и собственный цикл событий отсутствуют,
+код JavaScript выполняется исключительно в рамках настроенного обработчика,
+вызванного nginx, по завершении которого управление возвращается nginx.
 </para>
 
 <para>
@@ -41,6 +52,10 @@ njs - это модуль nginx, который расширяет возмож�
 
 <listitem>
 <link doc="install.xml"/>
+</listitem>
+
+<listitem>
+<link doc="integration.xml"/>
 </listitem>
 
 <listitem>

--- a/xml/ru/docs/njs/index.xml
+++ b/xml/ru/docs/njs/index.xml
@@ -9,7 +9,7 @@
 <article name="Модуль nginx JavaScript"
         link="/ru/docs/njs/index.html"
         lang="ru"
-        rev="40"
+        rev="41"
         toc="no">
 
 <section id="summary">
@@ -45,7 +45,7 @@ njs не является самостоятельной средой выпол
 </section>
 
 
-<section id="links">
+<section id="getting_started" name="Начало работы">
 
 <para>
 <list type="bullet">
@@ -59,50 +59,27 @@ njs не является самостоятельной средой выпол
 </listitem>
 
 <listitem>
-<link doc="changes.xml">Изменения в njs</link> [en]
-</listitem>
-
-<listitem>
-<link doc="reference.xml">Справочник</link> [en]
-</listitem>
-
-<listitem>
-<link doc="engine.xml"/>
-</listitem>
-
-<listitem>
-<link doc="native_modules.xml"/>
-</listitem>
-
-<listitem>
 <link url="https://github.com/nginx/njs-examples/">Примеры использования</link>
-</listitem>
-
-<listitem>
-<link doc="security.xml">Безопасность</link> [en]
-</listitem>
-
-<listitem>
-<link doc="compatibility.xml"/>
 </listitem>
 
 <listitem>
 <link doc="cli.xml"/>
 </listitem>
 
-<listitem>
-<link doc="preload_objects.xml"/>
-</listitem>
-
-<listitem>
-<link id="tested_os_and_platforms">Протестированные ОС и платформы</link>
-</listitem>
-
 </list>
 </para>
 
+</section>
+
+
+<section id="links" name="Справочная информация">
+
 <para>
 <list type="bullet">
+
+<listitem>
+<link doc="reference.xml">Справочник</link> [en]
+</listitem>
 
 <listitem>
 <link doc="../http/ngx_http_js_module.xml">
@@ -114,18 +91,51 @@ ngx_http_js_module</link>
 ngx_stream_js_module</link>
 </listitem>
 
-</list>
-</para>
+<listitem>
+<link doc="engine.xml"/>
+</listitem>
 
-<para>
-<list type="bullet">
+<listitem>
+<link doc="compatibility.xml"/>
+</listitem>
+
+<listitem>
+<link doc="native_modules.xml"/>
+</listitem>
+
+<listitem>
+<link doc="node_modules.xml"/>
+</listitem>
 
 <listitem>
 <link doc="typescript.xml"/>
 </listitem>
 
 <listitem>
-<link doc="node_modules.xml"/>
+<link doc="preload_objects.xml"/>
+</listitem>
+
+</list>
+</para>
+
+</section>
+
+
+<section id="project" name="О проекте">
+
+<para>
+<list type="bullet">
+
+<listitem>
+<link doc="changes.xml">Изменения в njs</link> [en]
+</listitem>
+
+<listitem>
+<link doc="security.xml">Безопасность</link> [en]
+</listitem>
+
+<listitem>
+<link id="tested_os_and_platforms">Протестированные ОС и платформы</link>
 </listitem>
 
 </list>

--- a/xml/ru/docs/njs/integration.xml
+++ b/xml/ru/docs/njs/integration.xml
@@ -1,0 +1,408 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (C) Nginx, Inc.
+  -->
+
+<!DOCTYPE article SYSTEM "../../../../dtd/article.dtd">
+
+<article name="Модель выполнения и точки интеграции"
+        link="/ru/docs/njs/integration.html"
+        lang="ru"
+        rev="1">
+
+<section id="summary">
+
+<para>
+Код JavaScript в <link doc="index.xml">njs</link> никогда
+не выполняется самостоятельно.
+nginx вызывает его в фиксированном наборе точек интеграции,
+каждая из которых связывается с обработчиком директивой конфигурации.
+Стартовый сценарий, фоновые потоки и собственный цикл событий отсутствуют:
+nginx вызывает обработчик, и по его завершении
+управление возвращается nginx.
+</para>
+
+<para>
+В статье приводятся сведения о вызове обработчиков
+и рекомендации по выбору подходящего.
+Подробное описание поведения директив см. в документации модулей
+<link doc="../http/ngx_http_js_module.xml">ngx_http_js_module</link>
+и
+<link doc="../stream/ngx_stream_js_module.xml">ngx_stream_js_module</link>.
+</para>
+
+</section>
+
+
+<section id="model" name="Модель выполнения">
+
+<para>
+<list type="enum">
+
+<listitem>
+При загрузке конфигурации директива
+<link doc="../http/ngx_http_js_module.xml" id="js_import">js_import</link>
+компилирует модули JavaScript.
+Синтаксические ошибки обнаруживаются на этом этапе,
+до начала обработки трафика nginx.
+</listitem>
+
+<listitem>
+Когда запрос или stream-сессия достигает одной из точек интеграции,
+создаётся контекст JavaScript.
+В нём выполняются импортированные модули,
+после чего вызываются настроенные обработчики.
+</listitem>
+
+<listitem>
+По завершении запроса или сессии контекст уничтожается
+либо, при использовании движка
+<link doc="engine.xml" id="quickjs_engine">QuickJS</link>,
+возвращается в пул повторно используемых контекстов.
+Остаются только данные, явно сохранённые в
+<link doc="reference.xml" id="ngx_shared">разделяемый словарь</link>
+или отправленные наружу.
+</listitem>
+
+</list>
+</para>
+
+<para>
+Единственная точка интеграции, не связанная с клиентским запросом, — это
+<literal>js_periodic</literal>, вызываемая по таймеру nginx.
+Код JavaScript не может создать собственную точку интеграции:
+он не может открыть слушающий сокет, породить поток
+или инициировать свой вызов вне обработчиков,
+заданных в конфигурации.
+</para>
+
+</section>
+
+
+<section id="http" name="Точки интеграции HTTP">
+
+<para>
+Обработчики получают первым аргументом объект
+<link doc="reference.xml" id="http">HTTP Request</link>,
+за исключением <literal>js_periodic</literal>,
+который получает объект
+<link doc="reference.xml" id="periodic_session">Periodic Session</link>.
+
+<table width="100%">
+
+<tr>
+<td width="27%"><b>Директива</b></td>
+<td width="38%"><b>Когда вызывается</b></td>
+<td width="35%"><b>Асинхронные операции</b></td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_access">
+<literal>js_access</literal></link></td>
+<td>на фазе доступа, до дальнейшей обработки запроса</td>
+<td>поддерживаются</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_content">
+<literal>js_content</literal></link></td>
+<td>на фазе содержимого, вместо проксирования
+или отдачи статического файла</td>
+<td>поддерживаются</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_header_filter">
+<literal>js_header_filter</literal></link></td>
+<td>один раз, когда заголовок ответа готов к отправке</td>
+<td>не поддерживаются</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_body_filter">
+<literal>js_body_filter</literal></link></td>
+<td>для каждого блока данных тела ответа</td>
+<td>не поддерживаются</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_set">
+<literal>js_set</literal></link></td>
+<td>при первом обращении к переменной,
+на той фазе, где это произошло,
+либо при каждом обращении с параметром <literal>nocache</literal></td>
+<td>не поддерживаются</td>
+</tr>
+
+<tr>
+<td><link doc="../http/ngx_http_js_module.xml" id="js_periodic">
+<literal>js_periodic</literal></link></td>
+<td>через заданные промежутки времени, без клиентского запроса</td>
+<td>поддерживаются</td>
+</tr>
+
+</table>
+</para>
+
+<para>
+Обработчики, для которых асинхронные операции не поддерживаются,
+должны получить результат до возврата управления:
+они не могут дождаться подзапроса, запроса наружу или таймера.
+Такой обработчик тем не менее может быть объявлен как
+<literal>async</literal>, если всё, что он ожидает,
+завершается немедленно.
+</para>
+
+<para>
+Обработчиков для фаз перезаписи и логирования нет.
+Переменная <literal>js_set</literal>, на которую ссылается директива
+соответствующей фазы, вычисляется на этой фазе,
+что и является обычным способом выполнить код
+в самом конце обработки запроса.
+</para>
+
+</section>
+
+
+<section id="stream" name="Точки интеграции stream">
+
+<para>
+Обработчики получают первым аргументом объект
+<link doc="reference.xml" id="stream">Stream Session</link>,
+за исключением <literal>js_periodic</literal>,
+который получает объект
+<link doc="reference.xml" id="periodic_session">Periodic Session</link>.
+
+<table width="100%">
+
+<tr>
+<td width="27%"><b>Директива</b></td>
+<td width="38%"><b>Когда вызывается</b></td>
+<td width="35%"><b>Асинхронные операции</b></td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_access">
+<literal>js_access</literal></link></td>
+<td>на фазе доступа</td>
+<td>в колбэках
+<link doc="reference.xml" id="s_on"><literal>s.on()</literal></link></td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_preread">
+<literal>js_preread</literal></link></td>
+<td>на фазе предварительного чтения,
+до подключения к проксируемому серверу</td>
+<td>в колбэках
+<link doc="reference.xml" id="s_on"><literal>s.on()</literal></link></td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_filter">
+<literal>js_filter</literal></link></td>
+<td>на фазе содержимого, для установки фильтров данных
+в обоих направлениях</td>
+<td>не поддерживаются</td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_set">
+<literal>js_set</literal></link></td>
+<td>при первом обращении к переменной,
+на той фазе, где это произошло,
+либо при каждом обращении с параметром <literal>nocache</literal></td>
+<td>не поддерживаются</td>
+</tr>
+
+<tr>
+<td><link doc="../stream/ngx_stream_js_module.xml" id="js_periodic">
+<literal>js_periodic</literal></link></td>
+<td>через заданные промежутки времени, без клиентской сессии</td>
+<td>поддерживаются</td>
+</tr>
+
+</table>
+</para>
+
+<para>
+Обработчики <literal>js_access</literal>, <literal>js_preread</literal>
+и <literal>js_filter</literal> вызываются один раз
+и предназначены для установки колбэков
+<link doc="reference.xml" id="s_on"><literal>s.on()</literal></link>
+для данных, которые придут позже.
+Сам обработчик должен вернуть управление сразу.
+</para>
+
+</section>
+
+
+<section id="choosing" name="Выбор точки интеграции">
+
+<para>
+<list type="tag">
+
+<tag-name>сформировать ответ, а не проксировать его</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_content">
+<literal>js_content</literal></link>
+</tag-desc>
+
+<tag-name>разрешить или запретить запрос или соединение,
+возможно, обратившись к внешнему сервису</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_access">
+<literal>js_access</literal></link>
+для запросов,
+<link doc="../stream/ngx_stream_js_module.xml" id="js_access">
+<literal>js_access</literal></link>
+для соединений или
+<link doc="../stream/ngx_stream_js_module.xml" id="js_preread">
+<literal>js_preread</literal></link>,
+если решение зависит от данных, присланных клиентом
+</tag-desc>
+
+<tag-name>вычислить значение для другой директивы nginx</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_set">
+<literal>js_set</literal></link>
+связывает обработчик с переменной,
+и именно так вычисленное значение попадает в
+<literal>proxy_pass</literal>, <literal>log_format</literal>
+и другие директивы, принимающие переменные.
+Вызванный ранее обработчик может также присвоить значение переменной,
+объявленной директивой
+<link doc="../http/ngx_http_js_module.xml" id="js_var">
+<literal>js_var</literal></link>, через
+<link doc="reference.xml" id="r_variables"><literal>r.variables</literal></link>
+</tag-desc>
+
+<tag-name>изменить ответ проксируемого сервера</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_header_filter">
+<literal>js_header_filter</literal></link>
+для заголовка,
+<link doc="../http/ngx_http_js_module.xml" id="js_body_filter">
+<literal>js_body_filter</literal></link>
+для тела
+</tag-desc>
+
+<tag-name>изменить поток байт проксируемого соединения</tag-name>
+<tag-desc>
+<link doc="../stream/ngx_stream_js_module.xml" id="js_filter">
+<literal>js_filter</literal></link>
+</tag-desc>
+
+<tag-name>обновить кэш, опросить API или отправить метрики
+без клиентского запроса</tag-name>
+<tag-desc>
+<link doc="../http/ngx_http_js_module.xml" id="js_periodic">
+<literal>js_periodic</literal></link>
+</tag-desc>
+
+</list>
+</para>
+
+<para>
+Для одного запроса можно использовать несколько обработчиков,
+например проверку доступа и вслед за ней фильтр тела ответа.
+Каждый из них является отдельным вызовом
+со своими ограничениями.
+</para>
+
+</section>
+
+
+<section id="state" name="Состояние и время жизни">
+
+<para>
+Код верхнего уровня модуля выполняется для каждого нового контекста
+JavaScript, то есть для каждого запроса или stream-сессии,
+в которых вызывается JavaScript.
+Для движка
+<link doc="engine.xml" id="quickjs_engine">QuickJS</link>
+контекст вместо этого может быть взят из пула повторно используемых
+контекстов, см.
+<link doc="../http/ngx_http_js_module.xml" id="js_context_reuse">
+js_context_reuse</link>;
+в этом случае модули заново не выполняются,
+а изменения, внесённые в область видимости модуля ранее, наследуются.
+</para>
+
+<para>
+<note>
+Поэтому переменные уровня модуля нельзя использовать
+для передачи данных между запросами или для кэширования результатов:
+в зависимости от движка и от повторного использования контекста
+такие данные либо теряются, либо наследуются от постороннего запроса.
+Дорогая инициализация в области видимости модуля
+также оплачивается для каждого нового контекста.
+</note>
+</para>
+
+<para>
+В nginx рабочие процессы по умолчанию
+не используют совместно память.
+njs предоставляет механизм для соместного использования состояния между рабочими
+процессами —
+<link doc="reference.xml" id="ngx_shared">разделяемый словарь</link>,
+объявляемый директивой
+<link doc="../http/ngx_http_js_module.xml" id="js_shared_dict_zone">
+js_shared_dict_zone</link>.
+</para>
+
+<para>
+Асинхронные операции, такие как
+<link doc="reference.xml" id="ngx_fetch"><literal>ngx.fetch()</literal></link>,
+<link doc="reference.xml" id="r_subrequest">
+<literal>r.subrequest()</literal></link>
+и
+<link doc="reference.xml" id="settimeout">
+<literal>setTimeout()</literal></link>,
+выполняются циклом событий nginx.
+Потоки не используются: обработчик, выполняющий длительные вычисления,
+блокирует весь рабочий процесс, а вместе с ним и любое другое соединение,
+обслуживаемое этим процессом.
+</para>
+
+</section>
+
+
+<section id="outside" name="Использование njs вне nginx">
+
+<para>
+<list type="bullet">
+
+<listitem>
+<link doc="cli.xml">Утилита командной строки</link>
+запускает njs без nginx, что удобно
+для разработки и отладки частей сценария,
+не зависящих от запроса.
+</listitem>
+
+<listitem>
+njs не является Node.js.
+В нём реализованы язык ECMAScript,
+набор <link doc="reference.xml">встроенных модулей</link>
+и объекты nginx,
+но не API Node.js и не разрешение имён пакетов.
+Тем не менее, библиотеки  можно использовать,
+если предварительно собрать их в один файл, см.
+<link doc="node_modules.xml"/>.
+</listitem>
+
+<listitem>
+<link doc="native_modules.xml">Нативные модули</link>
+расширяют njs кодом на C.
+Разделяемая библиотека загружается при разборе конфигурации,
+а зарегистрированный ею модуль затем импортируется,
+как любой другой.
+</listitem>
+
+</list>
+</para>
+
+</section>
+
+</article>

--- a/xml/ru/docs/stream/ngx_stream_js_module.xml
+++ b/xml/ru/docs/stream/ngx_stream_js_module.xml
@@ -9,14 +9,14 @@
 <module name="Модуль ngx_stream_js_module"
         link="/ru/docs/stream/ngx_stream_js_module.html"
         lang="ru"
-        rev="55">
+        rev="57">
 
 <section id="summary">
 
 <para>
 Модуль <literal>ngx_stream_js_module</literal> позволяет задавать
-обработчики на <link doc="../njs/index.xml">njs</link> —
-подмножестве языка JavaScript.
+обработчики сессий и переменных на JavaScript
+с помощью <link doc="../njs/index.xml">njs</link>.
 </para>
 
 <para>
@@ -560,7 +560,7 @@ server {
 <appeared-in>0.4.0</appeared-in>
 
 <para>
-Импортирует модуль, позволяющий задавать обработчики location и переменных
+Импортирует модуль, позволяющий задавать обработчики сессий и переменных
 на njs.
 <literal>Имя_экспорта</literal> является пространством имён
 при доступе к функциям модуля.
@@ -831,7 +831,8 @@ let result = mylib.add(5, 10);
 </para>
 
 <para>
-По умолчанию <literal>js_handler</literal> выполняется для рабочего процесса 0.
+По умолчанию обработчик <literal>js_periodic</literal>
+выполняется для рабочего процесса 0.
 Необязательный параметр <literal>worker_affinity</literal>
 позволяет указать рабочий процесс,
 для которого будет выполняться обработчик содержимого location.
@@ -909,9 +910,9 @@ async function handler(s) {
 Начиная с <link doc="../njs/changes.xml" id="njs0.8.6">0.8.6</link>,
 если указан необязательный параметр <literal>nocache</literal>, то
 обработчик выполняется каждый раз при обращении к переменной.
-Из-за ограничения модуля  <link doc="ngx_stream_rewrite_module.xml">rewrite</link>
+Из-за ограничения модуля <link doc="ngx_stream_set_module.xml">ngx_stream_set_module</link>
 при обращении к <literal>nocache</literal>-переменной при помощи
-директивы <link doc="ngx_stream_rewrite_module.xml" id="set">set</link>,
+директивы <link doc="ngx_stream_set_module.xml" id="set">set</link>,
 обработчик должен возвращать значение фиксированной длины.
 </para>
 


### PR DESCRIPTION
The landing page described what njs can do but never said how it is
invoked, which leaves newcomers expecting a standalone JavaScript runtime
next to nginx.  A new article lists every point where JavaScript can be
attached, tells when each handler runs and whether it may perform
asynchronous operations, and describes context lifetime, so that
module-level state is not mistaken for a cache