### PR TITLE
Linux packages: removed Debian 11 due to EOL.

### DIFF
--- a/xml/en/linux_packages.xml
+++ b/xml/en/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: Linux packages"
          link="/en/linux_packages.html"
          lang="en"
-         rev="117">
+         rev="118">
 
 <section name="Supported distributions and versions" id="distributions">
 
@@ -52,11 +52,6 @@ versions:
 <tr>
 <td width="30%">Version</td>
 <td>Supported Platforms</td>
-</tr>
-
-<tr>
-<td width="30%">11.x “bullseye”</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>

--- a/xml/ru/linux_packages.xml
+++ b/xml/ru/linux_packages.xml
@@ -7,7 +7,7 @@
 <article name="nginx: пакеты для Linux"
          link="/ru/linux_packages.html"
          lang="ru"
-         rev="117">
+         rev="118">
 
 <section name="Поддерживаемые дистрибутивы и версии" id="distributions">
 
@@ -52,11 +52,6 @@
 <tr>
 <td width="30%">Версия</td>
 <td>Поддерживаемые платформы</td>
-</tr>
-
-<tr>
-<td width="30%">11.x “bullseye”</td>
-<td>x86_64, aarch64/arm64</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
### Proposed changes

This PR removes Debian 11 from Linux packages page due to EOL.